### PR TITLE
Improve security headers and load performance

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,14 +5,17 @@
   <title>404 – Page Not Found | IronDillo</title>
   <meta name="description" content="Uh-oh. This burrow doesn’t exist. Let’s get you back to safety.">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
 
-  <!-- 🛡 Security Headers -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'none';">
-  <meta http-equiv="X-Content-Type-Options" content="nosniff">
-  <meta http-equiv="X-Frame-Options" content="DENY">
-  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
-  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
 
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
 

--- a/Drafts/blog-post-1.html
+++ b/Drafts/blog-post-1.html
@@ -4,6 +4,16 @@
   <meta charset="UTF-8" />
   <title>Draft: 5 Ways to Stay Safer Online</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
   <style>
     body {

--- a/about.html
+++ b/about.html
@@ -5,8 +5,18 @@
   <title>About | Iron Dillo Cybersecurity</title>
   <meta name="description" content="Learn more about Iron Dillo Cybersecurity, a veteran-owned business protecting East Texas individuals and small businesses with practical, trustworthy security solutions." />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
   <style>
     @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
     .fade-in { animation: fadeIn 1s ease-out both; }
@@ -16,7 +26,7 @@
 
   <!-- Header -->
   <header class="text-center pt-8 max-w-3xl mx-auto fade-in">
-    <img src="/assets/IronDilloLogo.png" alt="IronDillo cybersecurity logo" class="mx-auto mb-6 w-36 h-auto" />
+    <img loading="lazy" src="/assets/IronDilloLogo.png" alt="IronDillo cybersecurity logo" class="mx-auto mb-6 w-36 h-auto" />
   </header>
 
   <!-- Navigation -->

--- a/blog.html
+++ b/blog.html
@@ -5,6 +5,16 @@
   <title>Iron Dillo Blog – Cyber Hygiene Tips & Updates</title>
   <meta name="description" content="Cybersecurity guidance, threat breakdowns, and plain-English advice for real-world digital safety." />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" href="/assets/favicon.ico" />
   <link rel="canonical" href="https://irondillo.com/blog.html" />
 
@@ -18,7 +28,7 @@
   <meta name="twitter:card" content="summary_large_image" />
 
   <!-- Tailwind CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
   <style>
     @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
     .fade-in { animation: fadeIn 1s ease-out both; }
@@ -29,7 +39,7 @@
 
   <!-- Header with logo and nav -->
   <header class="p-8 text-center max-w-3xl mx-auto fade-in">
-    <img src="/assets/IronDilloLogo.png" alt="IronDillo Logo" class="mx-auto w-32 mb-6" />
+    <img loading="lazy" src="/assets/IronDilloLogo.png" alt="IronDillo Logo" class="mx-auto w-32 mb-6" />
     <h1 class="text-4xl font-extrabold text-teal-400 mb-4">Iron Dillo Blog</h1>
 
     <nav class="bg-gray-800 py-3 rounded-md mb-8 max-w-xl mx-auto">
@@ -51,7 +61,7 @@
  <main class="max-w-6xl mx-auto px-4 pb-20 grid gap-10 md:grid-cols-2 lg:grid-cols-3">
 
   <article class="bg-gray-800 rounded-lg overflow-hidden shadow-lg">
-    <img src="/assets/thumb-safer-online.jpg" alt="5 Ways to Stay Safer Online" class="w-full h-auto" />
+    <img loading="lazy" src="/assets/thumb-safer-online.jpg" alt="5 Ways to Stay Safer Online" class="w-full h-auto" />
     <div class="p-6">
       <h2 class="text-xl font-bold text-teal-300 mb-1">
         <a href="/posts/safer-online-now.html">5 Ways to Stay Safer Online Right Now</a>
@@ -62,7 +72,7 @@
   </article>
 
   <article class="bg-gray-800 rounded-lg overflow-hidden shadow-lg">
-    <img src="/assets/thumb-tech-support.png" alt="Tech Support Scam" class="w-full h-auto" />
+    <img loading="lazy" src="/assets/thumb-tech-support.png" alt="Tech Support Scam" class="w-full h-auto" />
     <div class="p-6">
       <h2 class="text-xl font-bold text-teal-300 mb-1">
         <a href="/posts/tech-support-scam-warning.html">How to Tell If That Tech Support Call Is a Scam</a>
@@ -73,7 +83,7 @@
   </article>
 
   <article class="bg-gray-800 rounded-lg overflow-hidden shadow-lg">
-    <img src="/assets/thumb-wordpress.jpg" alt="WordPress Security" class="w-full h-auto" />
+    <img loading="lazy" src="/assets/thumb-wordpress.jpg" alt="WordPress Security" class="w-full h-auto" />
     <div class="p-6">
       <h2 class="text-xl font-bold text-teal-300 mb-1">
         <a href="/posts/wordpress-security-basics.html">Basic WordPress Security for Beginners</a>
@@ -84,7 +94,7 @@
   </article>
 
   <article class="bg-gray-800 rounded-lg overflow-hidden shadow-lg">
-    <img src="/assets/thumb-tools.jpg" alt="Free Tools I Trust" class="w-full h-auto" />
+    <img loading="lazy" src="/assets/thumb-tools.jpg" alt="Free Tools I Trust" class="w-full h-auto" />
     <div class="p-6">
       <h2 class="text-xl font-bold text-teal-300 mb-1">
         <a href="/posts/free-tools-i-trust.html">Free Tools I Trust</a>
@@ -95,7 +105,7 @@
   </article>
 
   <article class="bg-gray-800 rounded-lg overflow-hidden shadow-lg">
-    <img src="/assets/thumb-ports.png" alt="Open Ports Explained" class="w-full h-48 object-cover" />
+    <img loading="lazy" src="/assets/thumb-ports.png" alt="Open Ports Explained" class="w-full h-48 object-cover" />
     <div class="p-6">
       <h2 class="text-xl font-bold text-teal-300 mb-1">
         <a href="/posts/closing-ports-backdoors.html">Are Open Ports a Backdoor?</a>
@@ -106,7 +116,7 @@
   </article>
 
   <article class="bg-gray-800 rounded-lg overflow-hidden shadow-lg">
-    <img src="/assets/thumb-rural.jpg" alt="Rural Cybersecurity" class="w-full h-auto" />
+    <img loading="lazy" src="/assets/thumb-rural.jpg" alt="Rural Cybersecurity" class="w-full h-auto" />
     <div class="p-6">
       <h2 class="text-xl font-bold text-teal-300 mb-1">
         <a href="/posts/rural-cybersecurity.html">Why Rural Businesses Can’t Ignore Cybersecurity</a>

--- a/commitment.html
+++ b/commitment.html
@@ -5,16 +5,26 @@
   <title>Our Commitment – Iron Dillo</title>
   <meta name="description" content="Iron Dillo Cybersecurity’s commitment to integrity, transparency, and client trust." />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <link rel="canonical" href="https://irondillo.com/commitment.html" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
 </head>
 
 <body class="flex flex-col min-h-screen bg-gray-900 text-gray-100 font-sans">
 
   <!-- Logo Header -->
   <header class="text-center pt-8">
-    <img src="/assets/IronDilloLogo.png" alt="IronDillo cybersecurity armadillo logo" class="mx-auto mb-6 w-36 h-auto" />
+    <img loading="lazy" src="/assets/IronDilloLogo.png" alt="IronDillo cybersecurity armadillo logo" class="mx-auto mb-6 w-36 h-auto" />
   </header>
 
   <!-- Navigation -->

--- a/contact.html
+++ b/contact.html
@@ -3,10 +3,20 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <title>Contact | Iron Dillo Cybersecurity</title>
   
   <!-- Tailwind CSS CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
   
   <!-- Google reCAPTCHA v2 -->
   <script src="https://www.google.com/recaptcha/api.js" async defer></script>
@@ -15,7 +25,7 @@
 
   <!-- Header -->
   <header class="text-center pt-8 max-w-3xl mx-auto">
-    <img src="/assets/IronDilloLogo.png" alt="IronDillo cybersecurity logo" class="mx-auto mb-6 w-36 h-auto" />
+    <img loading="lazy" src="/assets/IronDilloLogo.png" alt="IronDillo cybersecurity logo" class="mx-auto mb-6 w-36 h-auto" />
   </header>
 
   <!-- Navigation -->

--- a/index.html
+++ b/index.html
@@ -15,9 +15,19 @@
 
 <meta name="description" content="Iron Dillo Cybersecurity provides honest, hands-on protection for individuals, small businesses, and rural operations. Veteran-owned and mission-driven, offering remote diagnostics, documentation, and guidance you can trust." />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
 <link rel="icon" href="/assets/favicon.ico" />
-<script src="https://cdn.tailwindcss.com"></script>
-<script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+<script src="https://cdn.tailwindcss.com" defer></script>
+<script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 <style>
 @keyframes fadeIn {
 from { opacity: 0; }
@@ -32,7 +42,7 @@ animation: fadeIn 1.2s ease-out both;
 
 <!-- Header with logo, title, and navigation -->
 <header class="p-8 text-center max-w-3xl mx-auto fade-in">
-  <img src="/assets/IronDilloLogo.png" alt="IronDillo logo" class="mx-auto mb-6 w-32 h-auto" />
+  <img loading="lazy" src="/assets/IronDilloLogo.png" alt="IronDillo logo" class="mx-auto mb-6 w-32 h-auto" />
   <h1 class="text-4xl font-extrabold text-teal-400 mb-4">
     Iron Dillo Cybersecurity
   </h1>

--- a/maintenance.html
+++ b/maintenance.html
@@ -3,8 +3,18 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <title>Iron Dillo | Cyberstasis Mode</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
   <style>
     @keyframes matrixScroll {
       0% { transform: translateY(100%); opacity: 0; }
@@ -26,7 +36,7 @@
 
   <!-- Background Image -->
  <img
-  src="https://raw.githubusercontent.com/artilleryjoe/irondillo-site/main/assets/Cyber-stasis.png"
+  src="/assets/Cyber-stasis.png"
   alt="Cyberstasis Background"
   class="absolute inset-0 w-full h-full object-contain opacity-30 -z-10"
   style="filter: brightness(1.3);"

--- a/posts/closing-ports-backdoors.html
+++ b/posts/closing-ports-backdoors.html
@@ -5,16 +5,26 @@
   <title>Are Open Ports a Backdoor? | Iron Dillo Blog</title>
   <meta name="description" content="Learn how open ports can leave your devices exposed, how attackers exploit them, and how to lock them down securely.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" href="/assets/favicon.ico" />
   <link rel="canonical" href="https://irondillo.com/posts/closing-ports-backdoors.html" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
 </head>
 
 <body class="bg-gray-900 text-gray-100 font-sans flex flex-col min-h-screen">
 
   <!-- Logo + Nav -->
   <header class="text-center py-8 max-w-3xl mx-auto fade-in">
-    <img src="/assets/IronDilloLogo.png" alt="IronDillo Logo" class="mx-auto w-32 mb-6" />
+    <img loading="lazy" src="/assets/IronDilloLogo.png" alt="IronDillo Logo" class="mx-auto w-32 mb-6" />
     <h1 class="text-4xl font-extrabold text-teal-400 mb-4">Are Open Ports a Backdoor?</h1>
     <nav class="bg-gray-800 py-3 rounded-md mb-6 inline-block w-full max-w-md mx-auto">
       <div class="flex justify-center space-x-6">

--- a/posts/free-tools-i-trust.html
+++ b/posts/free-tools-i-trust.html
@@ -6,16 +6,26 @@
   <title>Free Tools I Trust (and Why You Should Too)</title>
   <meta name="description" content="A shortlist of battle-tested, free cybersecurity tools that actually help. No fluff, no upsells—just solid digital safety." />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="canonical" href="https://irondillo.com/posts/free-tools-i-trust.html" />
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <meta name="author" content="Kristopher McCoy">
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
 </head>
 <body class="bg-gray-900 text-gray-100 font-sans leading-relaxed">
 
   <!-- Header -->
   <header class="text-center py-10 px-4 max-w-3xl mx-auto">
-    <img src="/assets/IronDilloLogo.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6">
+    <img loading="lazy" src="/assets/IronDilloLogo.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6">
     <h1 class="text-4xl font-extrabold text-teal-400 mb-4">Free Tools I Trust (and Why You Should Too)</h1>
     <time datetime="2025-06-30" class="text-gray-400 text-xs mb-3 block">Published June 30, 2025</time>
     <p class="text-gray-300 max-w-xl mx-auto">Not every cybersecurity tool needs to come with a price tag—or an agenda. These are the ones I actually use, recommend, and trust to get the job done right.</p>

--- a/posts/rural-cybersecurity.html
+++ b/posts/rural-cybersecurity.html
@@ -7,6 +7,16 @@
   <link rel="canonical" href="https://irondillo.com/posts/rural-business-cybersecurity.html" />
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
 
   <!-- SEO -->
   <meta name="keywords" content="cybersecurity, rural business, East Texas, small business IT, cyber threats, ransomware, phishing">
@@ -17,13 +27,13 @@
   <meta property="og:url" content="https://irondillo.com/posts/rural-business-cybersecurity.html">
   <meta name="twitter:card" content="summary_large_image">
 
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
 </head>
 <body class="bg-gray-900 text-gray-100 font-sans leading-relaxed">
 
   <!-- Header -->
   <header class="text-center py-10 px-4 max-w-3xl mx-auto">
-    <img src="/assets/IronDilloLogo.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6">
+    <img loading="lazy" src="/assets/IronDilloLogo.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6">
     <h1 class="text-4xl font-extrabold text-teal-400 mb-4">Why Rural Businesses Can’t Ignore Cybersecurity</h1>
      <time datetime="2025-06-20" class="text-gray-400 text-sm block mb-6">Published June 20, 2025</time>
     <p class="text-gray-300 max-w-xl mx-auto">Hackers don’t care about your zip code—they care about how easy you are to break into. Let’s fix that.</p>

--- a/posts/safer-online-now.html
+++ b/posts/safer-online-now.html
@@ -6,6 +6,16 @@
   <meta name="description" content="Actionable steps to improve your online security today—strong passwords, phishing awareness, 2FA, and more.">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
 
   <!-- SEO -->
   <meta name="keywords" content="cybersecurity tips, online safety, password, 2FA, small business security, digital hygiene">
@@ -16,13 +26,13 @@
   <meta property="og:url" content="https://irondillo.com/posts/safer-online-now.html">
   <meta name="twitter:card" content="summary_large_image">
 
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
 </head>
 <body class="bg-gray-900 text-gray-100 font-sans leading-relaxed">
 
   <!-- Header -->
   <header class="text-center py-10 px-4 max-w-3xl mx-auto">
-    <img src="/assets/IronDilloLogo.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6">
+    <img loading="lazy" src="/assets/IronDilloLogo.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6">
     <h1 class="text-4xl font-extrabold text-teal-400 mb-4">5 Ways to Stay Safer Online Right Now</h1>
     <time datetime="2025-07-15" class="text-gray-400 text-xs mb-3 block">Published July 15, 2025</time>
     <p class="text-gray-300 max-w-xl mx-auto">You don’t need to be a tech wizard to defend yourself. Just build good habits—fast, simple, and Iron Dillo–approved.</p>

--- a/posts/tech-support-scam-warning.html
+++ b/posts/tech-support-scam-warning.html
@@ -6,6 +6,16 @@
   <meta name="description" content="Learn how to recognize and shut down tech support scam calls before they get your info." />
   <link rel="icon" href="/assets/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   
   <!-- SEO & Open Graph -->
   <meta name="keywords" content="cybersecurity, tech support scam, phone scam, phishing, social engineering" />
@@ -16,12 +26,12 @@
   <meta property="og:url" content="https://irondillo.com/posts/tech-support-scam-warning.html" />
   <meta name="twitter:card" content="summary_large_image" />
   
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
 </head>
 <body class="bg-gray-900 text-gray-100 font-sans leading-relaxed px-6 max-w-3xl mx-auto py-10">
 
   <header class="text-center mb-10">
-    <img src="/assets/IronDilloLogo.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6" />
+    <img loading="lazy" src="/assets/IronDilloLogo.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6" />
     <h1 class="text-4xl font-extrabold text-teal-400 mb-2">How to Tell If That “Tech Support” Call Is a Scam</h1>
     <time datetime="2025-10-22" class="text-gray-400 text-sm block mb-6">Published July 10, 2025</time>
     <p class="text-gray-300 max-w-xl mx-auto">

--- a/posts/wordpress-security-basics.html
+++ b/posts/wordpress-security-basics.html
@@ -7,6 +7,16 @@
   <link rel="canonical" href="https://irondillo.com/posts/wordpress-security-basics.html" />
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
 
   <!-- SEO -->
   <meta name="keywords" content="WordPress security, beginner WordPress, website protection, cybersecurity tips" />
@@ -17,13 +27,13 @@
   <meta property="og:url" content="https://irondillo.com/posts/wordpress-security-basics.html" />
   <meta name="twitter:card" content="summary_large_image" />
 
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
 </head>
 <body class="bg-gray-900 text-gray-100 font-sans leading-relaxed">
 
   <!-- Header -->
   <header class="text-center py-10 px-6 max-w-3xl mx-auto">
-    <img src="/assets/IronDilloLogo.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6" />
+    <img loading="lazy" src="/assets/IronDilloLogo.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6" />
     <h1 class="text-4xl font-extrabold text-teal-400 mb-4">Basic WordPress Security for Beginners</h1>
     <time datetime="2025-07-05" class="text-gray-400 text-sm block mb-6">Published July 5, 2025</time>
     <p class="text-gray-300 max-w-xl mx-auto">Launching a WordPress site is easy — securing it doesn't have to be complicated. These five practical steps will protect your site from common attacks without needing to be a tech expert.</p>

--- a/privacy.html
+++ b/privacy.html
@@ -5,16 +5,26 @@
   <title>Privacy Policy – Iron Dillo</title>
   <meta name="description" content="Iron Dillo respects your privacy—no cookies, no tracking, no nonsense. Read our full policy here." />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <link rel="canonical" href="https://irondillo.com/privacy.html" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
 </head>
 
 <body class="flex flex-col min-h-screen bg-gray-900 text-gray-100 font-sans">
 
   <!-- Logo Header -->
   <header class="text-center pt-8">
-    <img src="/assets/IronDilloLogo.png" alt="IronDillo cybersecurity armadillo logo" class="mx-auto mb-6 w-36 h-auto" />
+    <img loading="lazy" src="/assets/IronDilloLogo.png" alt="IronDillo cybersecurity armadillo logo" class="mx-auto mb-6 w-36 h-auto" />
   </header>
 
   <!-- Navigation -->

--- a/services.html
+++ b/services.html
@@ -5,8 +5,18 @@
   <title>Services | Iron Dillo Cybersecurity</title>
   <meta name="description" content="Explore the cybersecurity services offered by Iron Dillo, focused on protecting East Texas individuals and small businesses with practical, ethical solutions." />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
   <style>
     @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
     .fade-in { animation: fadeIn 1s ease-out both; }
@@ -16,7 +26,7 @@
 
   <!-- Logo Header -->
   <header class="text-center pt-8 max-w-3xl mx-auto fade-in">
-    <img src="/assets/IronDilloLogo.png" alt="IronDillo cybersecurity armadillo logo" class="mx-auto mb-6 w-36 h-auto" />
+    <img loading="lazy" src="/assets/IronDilloLogo.png" alt="IronDillo cybersecurity armadillo logo" class="mx-auto mb-6 w-36 h-auto" />
   </header>
 
   <!-- Navigation -->

--- a/terms.html
+++ b/terms.html
@@ -5,15 +5,25 @@
   <title>Terms of Use – IronDillo</title>
   <meta name="description" content="Understand the rules and disclaimers for using IronDillo's content, contact form, and services." />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="preconnect" href="https://cdn.tailwindcss.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- 🛡 Security Headers -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="DENY">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <link rel="canonical" href="https://irondillo.com/terms.html" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
 </head>
 <body class="flex flex-col min-h-screen bg-gray-900 text-gray-100 font-sans">
 
   <!-- Logo Header -->
   <header class="text-center pt-8">
-    <img src="/assets/IronDilloLogo.png" alt="IronDillo cybersecurity armadillo logo" class="mx-auto mb-6 w-36 h-auto" />
+    <img loading="lazy" src="/assets/IronDilloLogo.png" alt="IronDillo cybersecurity armadillo logo" class="mx-auto mb-6 w-36 h-auto" />
     <h1 class="text-4xl font-extrabold text-teal-400 mb-2">Terms of Use</h1>
     <p class="text-gray-400">Effective Date: June 12, 2025</p>
   </header>


### PR DESCRIPTION
## Summary
- add preconnect hints and security headers across all pages
- defer Tailwind script and lazy load images
- use local Cyber-stasis image for maintenance page

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688845a631e48322a8aa79f01daf6ae3