### PR TITLE
Fix sitemap nesting

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -75,7 +75,8 @@
     <loc>https://irondillo.com/terms.html</loc>
     <priority>0.3</priority>
     <changefreq>yearly</changefreq>
-     <url>
+  </url>
+  <url>
     <loc>https://irondillo.com/commitment.html</loc>
     <priority>0.3</priority>
     <changefreq>yearly</changefreq>


### PR DESCRIPTION
## Summary
- fix malformed XML in `sitemap.xml`

## Testing
- `python3 - <<'EOF'
import xml.etree.ElementTree as ET
try:
    ET.parse('sitemap.xml')
    print('XML valid')
except Exception as e:
    print('Error:', e)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6888379f46ec83228b643c77d85f8077