### PR TITLE
Add meta security headers across pages

### DIFF
--- a/Drafts/blog-post-1.html
+++ b/Drafts/blog-post-1.html
@@ -4,6 +4,13 @@
   <meta charset="UTF-8" />
   <title>Draft: 5 Ways to Stay Safer Online</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
   <style>
     body {

--- a/about.html
+++ b/about.html
@@ -5,6 +5,13 @@
   <title>About | Iron Dillo Cybersecurity</title>
   <meta name="description" content="Learn more about Iron Dillo Cybersecurity, a veteran-owned business protecting East Texas individuals and small businesses with practical, trustworthy security solutions." />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <script src="https://cdn.tailwindcss.com"></script>
   <style>

--- a/blog.html
+++ b/blog.html
@@ -5,6 +5,13 @@
   <title>Iron Dillo Blog – Cyber Hygiene Tips & Updates</title>
   <meta name="description" content="Cybersecurity guidance, threat breakdowns, and plain-English advice for real-world digital safety." />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" href="/assets/favicon.ico" />
   <link rel="canonical" href="https://irondillo.com/blog.html" />
 

--- a/commitment.html
+++ b/commitment.html
@@ -5,6 +5,13 @@
   <title>Our Commitment – Iron Dillo</title>
   <meta name="description" content="Iron Dillo Cybersecurity’s commitment to integrity, transparency, and client trust." />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <link rel="canonical" href="https://irondillo.com/commitment.html" />
   <script src="https://cdn.tailwindcss.com"></script>

--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <title>Contact | Iron Dillo Cybersecurity</title>
   
   <!-- Tailwind CSS CDN -->

--- a/index.html
+++ b/index.html
@@ -15,6 +15,13 @@
 
 <meta name="description" content="Iron Dillo Cybersecurity provides honest, hands-on protection for individuals, small businesses, and rural operations. Veteran-owned and mission-driven, offering remote diagnostics, documentation, and guidance you can trust." />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
 <link rel="icon" href="/assets/favicon.ico" />
 <script src="https://cdn.tailwindcss.com"></script>
 <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>

--- a/maintenance.html
+++ b/maintenance.html
@@ -3,6 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <title>Iron Dillo | Cyberstasis Mode</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>

--- a/posts/closing-ports-backdoors.html
+++ b/posts/closing-ports-backdoors.html
@@ -5,6 +5,13 @@
   <title>Are Open Ports a Backdoor? | Iron Dillo Blog</title>
   <meta name="description" content="Learn how open ports can leave your devices exposed, how attackers exploit them, and how to lock them down securely.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" href="/assets/favicon.ico" />
   <link rel="canonical" href="https://irondillo.com/posts/closing-ports-backdoors.html" />
   <script src="https://cdn.tailwindcss.com"></script>

--- a/posts/free-tools-i-trust.html
+++ b/posts/free-tools-i-trust.html
@@ -6,6 +6,13 @@
   <title>Free Tools I Trust (and Why You Should Too)</title>
   <meta name="description" content="A shortlist of battle-tested, free cybersecurity tools that actually help. No fluff, no upsells—just solid digital safety." />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="canonical" href="https://irondillo.com/posts/free-tools-i-trust.html" />
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <meta name="author" content="Kristopher McCoy">

--- a/posts/rural-cybersecurity.html
+++ b/posts/rural-cybersecurity.html
@@ -7,6 +7,13 @@
   <link rel="canonical" href="https://irondillo.com/posts/rural-business-cybersecurity.html" />
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
 
   <!-- SEO -->
   <meta name="keywords" content="cybersecurity, rural business, East Texas, small business IT, cyber threats, ransomware, phishing">

--- a/posts/safer-online-now.html
+++ b/posts/safer-online-now.html
@@ -6,6 +6,13 @@
   <meta name="description" content="Actionable steps to improve your online security today—strong passwords, phishing awareness, 2FA, and more.">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
 
   <!-- SEO -->
   <meta name="keywords" content="cybersecurity tips, online safety, password, 2FA, small business security, digital hygiene">

--- a/posts/tech-support-scam-warning.html
+++ b/posts/tech-support-scam-warning.html
@@ -6,6 +6,13 @@
   <meta name="description" content="Learn how to recognize and shut down tech support scam calls before they get your info." />
   <link rel="icon" href="/assets/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   
   <!-- SEO & Open Graph -->
   <meta name="keywords" content="cybersecurity, tech support scam, phone scam, phishing, social engineering" />

--- a/posts/wordpress-security-basics.html
+++ b/posts/wordpress-security-basics.html
@@ -7,6 +7,13 @@
   <link rel="canonical" href="https://irondillo.com/posts/wordpress-security-basics.html" />
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
 
   <!-- SEO -->
   <meta name="keywords" content="WordPress security, beginner WordPress, website protection, cybersecurity tips" />

--- a/privacy.html
+++ b/privacy.html
@@ -5,6 +5,13 @@
   <title>Privacy Policy – Iron Dillo</title>
   <meta name="description" content="Iron Dillo respects your privacy—no cookies, no tracking, no nonsense. Read our full policy here." />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <link rel="canonical" href="https://irondillo.com/privacy.html" />
   <script src="https://cdn.tailwindcss.com"></script>

--- a/services.html
+++ b/services.html
@@ -5,6 +5,13 @@
   <title>Services | Iron Dillo Cybersecurity</title>
   <meta name="description" content="Explore the cybersecurity services offered by Iron Dillo, focused on protecting East Texas individuals and small businesses with practical, ethical solutions." />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <script src="https://cdn.tailwindcss.com"></script>
   <style>

--- a/terms.html
+++ b/terms.html
@@ -5,6 +5,13 @@
   <title>Terms of Use – IronDillo</title>
   <meta name="description" content="Understand the rules and disclaimers for using IronDillo's content, contact form, and services." />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- 🛡 Security Headers -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta http-equiv="X-Frame-Options" content="DENY">
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+  <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <link rel="canonical" href="https://irondillo.com/terms.html" />
   <script src="https://cdn.tailwindcss.com"></script>


### PR DESCRIPTION
## Summary
- insert Content-Security-Policy and related security headers on all HTML pages

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688841571c948322993f4409a8156c03