### PR TITLE
Apply brand colors and fonts

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,6 +8,7 @@
 <link rel="preconnect" href="https://cdn.tailwindcss.com">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
@@ -16,9 +17,7 @@
 <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
 <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
 
-
   <link rel="icon" type="image/x-icon" href="/assets/favicon.png">
-
   <style>
     body {
       background: #f4e1c1;
@@ -31,16 +30,13 @@
       max-width: 300px;
       height: auto;
       margin: 2rem auto;
-    }
     h1 {
       font-size: 2rem;
       color: #444;
-    }
     p {
       font-size: 1.1rem;
       margin: 1rem auto;
       max-width: 600px;
-    }
     a {
       display: inline-block;
       margin-top: 1.5rem;
@@ -50,11 +46,9 @@
       text-decoration: none;
       font-weight: bold;
       border-radius: 5px;
-    }
   </style>
 </head>
-
-<body>
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
   <img src="/assets/404Dillo.png" alt="Dizzy Armadillo - Couldn't Find This Burrow">
   <h1>404 – Couldn't Find This Burrow</h1>
   <p>Looks like the page you're digging for doesn't exist. Maybe it got buried, maybe it never existed at all. No worries—Iron Dillo is on the trail.</p>

--- a/Drafts/blog-post-1.html
+++ b/Drafts/blog-post-1.html
@@ -9,6 +9,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
 <meta http-equiv="X-Frame-Options" content="DENY">
 <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
@@ -26,41 +27,28 @@
     }
     h1, h2 {
       color: #00ffc3;
-    }
     p {
       font-size: 1.1rem;
       line-height: 1.6;
-    }
     a {
-      color: #00ffc3;
       text-decoration: underline;
-    }
   </style>
 </head>
 
-<body>
-
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
   <h1>5 Ways to Stay Safer Online Right Now</h1>
-
   <p>You don’t need to be a tech wizard to stay safe online. Just a few simple habits can make you way harder to hack. Let’s hit five of them—fast, clean, and Iron Dillo–approved.</p>
-
   <h2>1. Stop Reusing Passwords</h2>
   <p>Use a password manager like Bitwarden or KeePass. Each site gets its own strong password—no repeats.</p>
-
   <h2>2. Turn On Two-Factor Authentication (2FA)</h2>
   <p>App-based codes like Authy or Google Authenticator are better than SMS. Use them anywhere you can.</p>
-
   <h2>3. Update Your Stuff</h2>
   <p>Browsers, phones, apps—if it runs software, patch it. Most hacks come from old junk.</p>
-
   <h2>4. Don’t Click Suspicious Links</h2>
   <p>Emails, texts, DMs—double check the sender, hover before you click, and never trust a link you didn’t ask for.</p>
-
   <h2>5. Avoid Running as Admin</h2>
   <p>Use daily accounts with limited privileges. If malware hits, it can’t hijack your whole system.</p>
-
   <hr>
   <p>Want help putting this into action? <a href="/services.html">Let's talk security</a>.</p>
-
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -8,6 +8,7 @@
 <link rel="preconnect" href="https://cdn.tailwindcss.com">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
@@ -17,42 +18,42 @@
 <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.png" />
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
   <style>
     @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
     .fade-in { animation: fadeIn 1s ease-out both; }
   </style>
 </head>
-<body class="flex flex-col min-h-screen bg-gray-900 text-gray-100 font-sans">
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
 
   <!-- Header -->
   <header class="text-center pt-8 max-w-3xl mx-auto fade-in">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo cybersecurity logo" class="mx-auto mb-6 w-36 h-auto" />
   </header>
-
   <!-- Navigation -->
-  <nav class="bg-gray-800 py-3 rounded-md mb-8 max-w-xl mx-auto fade-in">
+  <nav class="bg-armadilloGray py-3 rounded-md mb-8 max-w-xl mx-auto fade-in">
     <div class="flex justify-between">
-      <a href="/index.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Home</a>
-      <a href="/services.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Services</a>
-      <a href="/about.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">About</a>
-      <a href="/contact.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Contact</a>
+      <a href="/index.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Home</a>
+      <a href="/services.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Services</a>
+      <a href="/about.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">About</a>
+      <a href="/contact.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Contact</a>
     </div>
   </nav>
-
   <!-- Main Content -->
   <main class="flex-grow max-w-3xl mx-auto px-6 py-12 space-y-12 fade-in">
     
     <!-- Intro -->
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8 text-center">
-      <h1 class="text-3xl font-bold text-teal-400 mb-4">About Iron Dillo Cybersecurity</h1>
-      <p class="text-gray-300 leading-relaxed">
+    <section class="bg-armadilloGray rounded-lg shadow-lg p-8 text-center">
+      <h1 class="text-3xl font-bold text-oliveGreen mb-4">About Iron Dillo Cybersecurity</h1>
+      <p class="text-armadilloGray leading-relaxed">
         Iron Dillo Cybersecurity is a veteran-owned business dedicated to protecting individuals,
         small businesses, and rural communities across East Texas with practical, trustworthy cybersecurity solutions.
       </p>
     </section>
-
     <!-- Story -->
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8 flex flex-col md:flex-row items-center md:items-start gap-8">
+    <section class="bg-armadilloGray rounded-lg shadow-lg p-8 flex flex-col md:flex-row items-center md:items-start gap-8">
   <!-- Image -->
   <div class="w-40 h-40 md:w-56 md:h-56 flex-shrink-0">
     <img 
@@ -61,75 +62,55 @@
       class="rounded-full object-cover w-full h-full shadow-md"
     >
   </div>
-
   <!-- Text -->
   <div>
-    <h2 class="text-2xl font-semibold text-teal-300 mb-4">Meet Kris McCoy</h2>
-    <p class="text-gray-300 leading-relaxed">
+    <h2 class="text-2xl font-semibold text-oliveGreen mb-4">Meet Kris McCoy</h2>
+    <p class="text-armadilloGray leading-relaxed">
       I served in the U.S. Army in field artillery during Operation Enduring Freedom. After my service,
       I earned a Master of Science in Cybersecurity with distinction and am continuing my education through
       the WGU Business School. Today, I’m proud to be active in the East Texas business community!
     </p>
-    <p class="text-gray-300 leading-relaxed mt-4">
+    <p class="text-armadilloGray leading-relaxed mt-4">
       I am pursuing the CISSP in order to strengthen my ability to serve clients,
       and I bring the same discipline, vigilance, and integrity from my military service into every project.
-    </p>
-  </div>
 </section>
-
-
     <!-- Ethics Commitment -->
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8">
-      <h2 class="text-2xl font-semibold text-teal-300 mb-4">Commitment to Professional Ethics</h2>
-      <p class="text-gray-300 leading-relaxed">
+    <section class="bg-armadilloGray rounded-lg shadow-lg p-8">
+      <h2 class="text-2xl font-semibold text-oliveGreen mb-4">Commitment to Professional Ethics</h2>
         As a member of <span class="font-semibold text-white">ISC2</span>, I keep their 
-        <a href="https://www.isc2.org/Ethics" target="_blank" class="text-teal-400 hover:underline">
+        <a href="https://www.isc2.org/Ethics" target="_blank" class="text-oliveGreen hover:underline">
           Code of Ethics
         </a> close to heart in this work. 
         These principles emphasize protecting society and the common good, acting with honesty and diligence, 
         delivering competent service to those I serve, and advancing the cybersecurity profession for the future.
-      </p>
-      <p class="text-gray-300 leading-relaxed mt-4">
+      <p class="text-armadilloGray leading-relaxed mt-4">
         For my clients, this means every engagement is conducted with transparency, responsibility, and 
         a commitment to solutions that put their security and trust first.
-      </p>
-    </section>
-
     <!-- Values -->
     <section class="py-12 grid gap-6 md:grid-cols-3 text-center">
-      <div class="bg-gray-800 p-6 rounded-lg shadow-lg">
-        <h3 class="text-xl font-bold text-teal-400 mb-2">Integrity</h3>
-        <p class="text-gray-300 text-sm">Honest, ethical guidance in every engagement.</p>
+      <div class="bg-armadilloGray p-6 rounded-lg shadow-lg">
+        <h3 class="text-xl font-bold text-oliveGreen mb-2">Integrity</h3>
+        <p class="text-armadilloGray text-sm">Honest, ethical guidance in every engagement.</p>
       </div>
-      <div class="bg-gray-800 p-6 rounded-lg shadow-lg">
-        <h3 class="text-xl font-bold text-teal-400 mb-2">Discipline</h3>
-        <p class="text-gray-300 text-sm">A veteran’s focus on detail and thoroughness.</p>
-      </div>
-      <div class="bg-gray-800 p-6 rounded-lg shadow-lg">
-        <h3 class="text-xl font-bold text-teal-400 mb-2">Resilience</h3>
-        <p class="text-gray-300 text-sm">Helping your business prepare, withstand, and recover from threats.</p>
-      </div>
-    </section>
-
+        <h3 class="text-xl font-bold text-oliveGreen mb-2">Discipline</h3>
+        <p class="text-armadilloGray text-sm">A veteran’s focus on detail and thoroughness.</p>
+        <h3 class="text-xl font-bold text-oliveGreen mb-2">Resilience</h3>
+        <p class="text-armadilloGray text-sm">Helping your business prepare, withstand, and recover from threats.</p>
     <!-- Call to Action -->
-    <section class="bg-gray-900 py-12 text-center">
+    <section class="bg-armadilloBlack py-12 text-center">
       <h2 class="text-2xl font-bold text-white mb-4">Ready to Secure Your Business</h2>
-      <p class="text-gray-300 max-w-xl mx-auto">
+      <p class="text-armadilloGray max-w-xl mx-auto">
         Iron Dillo Cybersecurity is here to provide straightforward, hands-on support for East Texas 
         individuals and businesses. Let’s talk about the right plan for your needs.
-      </p>
-      <a href="/contact.html" class="mt-6 inline-block bg-teal-500 text-white px-6 py-3 rounded-lg shadow-lg hover:bg-teal-600 transition">
+      <a href="/contact.html" class="mt-6 inline-block bg-oliveGreen text-white px-6 py-3 rounded-lg shadow-lg hover:bg-oliveDark transition">
         Contact Me Today
       </a>
-    </section>
   </main>
-
   <!-- Footer -->
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 mt-auto text-sm max-w-3xl mx-auto rounded-md fade-in">
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 mt-auto text-sm max-w-3xl mx-auto rounded-md fade-in">
     &copy; 2025 Iron Dillo. All rights reserved. | Veteran-Owned | 
-    <a href="/privacy.html" class="hover:underline text-teal-400">Privacy</a> | 
-    <a href="/terms.html" class="hover:underline text-teal-400">Terms</a>
+    <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> | 
+    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
   </footer>
-
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -11,6 +11,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
 <meta http-equiv="X-Frame-Options" content="DENY">
 <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
@@ -27,115 +28,72 @@
   <meta property="og:image" content="https://irondillo.com/assets/irondillo-preview.png" />
   <meta property="og:url" content="https://irondillo.com/blog.html" />
   <meta name="twitter:card" content="summary_large_image" />
-
   <!-- Tailwind CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
   <style>
     @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
     .fade-in { animation: fadeIn 1s ease-out both; }
   </style>
 </head>
-
-<body class="bg-gray-900 text-gray-100 font-sans flex flex-col min-h-screen">
-
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
   <!-- Header with logo and nav -->
   <header class="p-8 text-center max-w-3xl mx-auto fade-in">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo Logo" class="mx-auto w-32 mb-6" />
-    <h1 class="text-4xl font-extrabold text-teal-400 mb-4">Iron Dillo Blog</h1>
-
-    <nav class="bg-gray-800 py-3 rounded-md mb-8 max-w-xl mx-auto">
+    <h1 class="text-4xl font-extrabold text-oliveGreen mb-4">Iron Dillo Blog</h1>
+    <nav class="bg-armadilloGray py-3 rounded-md mb-8 max-w-xl mx-auto">
       <div class="flex justify-between">
-        <a href="/index.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Home</a>
-        <a href="/services.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Services</a>
-        <a href="/about.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">About</a>
-        <a href="/blog.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Blog</a>
-        <a href="/contact.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Contact</a>
+        <a href="/index.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Home</a>
+        <a href="/services.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Services</a>
+        <a href="/about.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">About</a>
+        <a href="/blog.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Blog</a>
+        <a href="/contact.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Contact</a>
       </div>
     </nav>
-
-    <p class="text-gray-300 max-w-xl mx-auto">
+    <p class="text-armadilloGray max-w-xl mx-auto">
       Cybersecurity guidance, digital hygiene tips, and insights for real people and small businesses.
     </p>
   </header>
-
   <!-- Blog Posts Grid -->
  <main class="max-w-6xl mx-auto px-4 pb-20 grid gap-10 md:grid-cols-2 lg:grid-cols-3">
-
-  <article class="bg-gray-800 rounded-lg overflow-hidden shadow-lg">
+  <article class="bg-armadilloGray rounded-lg overflow-hidden shadow-lg">
     <img loading="lazy" src="/assets/thumb-safer-online.jpg" alt="5 Ways to Stay Safer Online" class="w-full h-auto" />
     <div class="p-6">
-      <h2 class="text-xl font-bold text-teal-300 mb-1">
+      <h2 class="text-xl font-bold text-oliveGreen mb-1">
         <a href="/posts/safer-online-now.html">5 Ways to Stay Safer Online Right Now</a>
       </h2>
-      <p class="text-gray-400 text-xs mb-3">Published: July 15, 2025</p>
-      <p class="text-gray-300 text-sm">Quick, actionable cybersecurity advice for real people and small businesses. Start here.</p>
+      <p class="text-armadilloGray text-xs mb-3">Published: July 15, 2025</p>
+      <p class="text-armadilloGray text-sm">Quick, actionable cybersecurity advice for real people and small businesses. Start here.</p>
     </div>
   </article>
-
-  <article class="bg-gray-800 rounded-lg overflow-hidden shadow-lg">
     <img loading="lazy" src="/assets/thumb-tech-support.png" alt="Tech Support Scam" class="w-full h-auto" />
-    <div class="p-6">
-      <h2 class="text-xl font-bold text-teal-300 mb-1">
         <a href="/posts/tech-support-scam-warning.html">How to Tell If That Tech Support Call Is a Scam</a>
-      </h2>
-      <p class="text-gray-400 text-xs mb-3">Published: July 10, 2025</p>
-      <p class="text-gray-300 text-sm">Don’t get tricked by cold-callers claiming your account was hacked. Learn how to spot the red flags.</p>
-    </div>
-  </article>
-
-  <article class="bg-gray-800 rounded-lg overflow-hidden shadow-lg">
+      <p class="text-armadilloGray text-xs mb-3">Published: July 10, 2025</p>
+      <p class="text-armadilloGray text-sm">Don’t get tricked by cold-callers claiming your account was hacked. Learn how to spot the red flags.</p>
     <img loading="lazy" src="/assets/thumb-wordpress.jpg" alt="WordPress Security" class="w-full h-auto" />
-    <div class="p-6">
-      <h2 class="text-xl font-bold text-teal-300 mb-1">
         <a href="/posts/wordpress-security-basics.html">Basic WordPress Security for Beginners</a>
-      </h2>
-      <p class="text-gray-400 text-xs mb-3">Published: July 5, 2025</p>
-      <p class="text-gray-300 text-sm">WordPress makes it easy to launch a site, but simplicity comes with security risks.</p>
-    </div>
-  </article>
-
-  <article class="bg-gray-800 rounded-lg overflow-hidden shadow-lg">
+      <p class="text-armadilloGray text-xs mb-3">Published: July 5, 2025</p>
+      <p class="text-armadilloGray text-sm">WordPress makes it easy to launch a site, but simplicity comes with security risks.</p>
     <img loading="lazy" src="/assets/thumb-tools.jpg" alt="Free Tools I Trust" class="w-full h-auto" />
-    <div class="p-6">
-      <h2 class="text-xl font-bold text-teal-300 mb-1">
         <a href="/posts/free-tools-i-trust.html">Free Tools I Trust</a>
-      </h2>
-      <p class="text-gray-400 text-xs mb-3">Published: June 30, 2025</p>
-      <p class="text-gray-300 text-sm">Not every cybersecurity tool costs money—or your sanity.</p>
-    </div>
-  </article>
-
-  <article class="bg-gray-800 rounded-lg overflow-hidden shadow-lg">
+      <p class="text-armadilloGray text-xs mb-3">Published: June 30, 2025</p>
+      <p class="text-armadilloGray text-sm">Not every cybersecurity tool costs money—or your sanity.</p>
     <img loading="lazy" src="/assets/thumb-ports.png" alt="Open Ports Explained" class="w-full h-48 object-cover" />
-    <div class="p-6">
-      <h2 class="text-xl font-bold text-teal-300 mb-1">
         <a href="/posts/closing-ports-backdoors.html">Are Open Ports a Backdoor?</a>
-      </h2>
-      <p class="text-gray-400 text-xs mb-3">Published: June 25, 2025</p>
-      <p class="text-gray-300 text-sm">Open ports are like doors into your system. Some are needed. Some aren't.</p>
-    </div>
-  </article>
-
-  <article class="bg-gray-800 rounded-lg overflow-hidden shadow-lg">
+      <p class="text-armadilloGray text-xs mb-3">Published: June 25, 2025</p>
+      <p class="text-armadilloGray text-sm">Open ports are like doors into your system. Some are needed. Some aren't.</p>
     <img loading="lazy" src="/assets/thumb-rural.jpg" alt="Rural Cybersecurity" class="w-full h-auto" />
-    <div class="p-6">
-      <h2 class="text-xl font-bold text-teal-300 mb-1">
         <a href="/posts/rural-cybersecurity.html">Why Rural Businesses Can’t Ignore Cybersecurity</a>
-      </h2>
-      <p class="text-gray-400 text-xs mb-3">Published: June 20, 2025</p>
-      <p class="text-gray-300 text-sm">When folks think about hackers, they picture big cities. That’s a mistake.</p>
-    </div>
-  </article>
-
+      <p class="text-armadilloGray text-xs mb-3">Published: June 20, 2025</p>
+      <p class="text-armadilloGray text-sm">When folks think about hackers, they picture big cities. That’s a mistake.</p>
 </main>
-
-
   <!-- Footer -->
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 text-sm mt-auto max-w-3xl mx-auto rounded-md">
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 text-sm mt-auto max-w-3xl mx-auto rounded-md">
     &copy; 2025 Iron Dillo. All rights reserved. |
-    <a href="/privacy.html" class="hover:underline text-teal-400">Privacy</a> |
-    <a href="/terms.html" class="hover:underline text-teal-400">Terms</a>
+    <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> |
+    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
   </footer>
-
 </body>
 </html>

--- a/commitment.html
+++ b/commitment.html
@@ -8,6 +8,7 @@
 <link rel="preconnect" href="https://cdn.tailwindcss.com">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
@@ -18,35 +19,33 @@
   <link rel="icon" type="image/x-icon" href="/assets/favicon.png" />
   <link rel="canonical" href="https://irondillo.com/commitment.html" />
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
 </head>
 
-<body class="flex flex-col min-h-screen bg-gray-900 text-gray-100 font-sans">
-
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
   <!-- Logo Header -->
   <header class="text-center pt-8">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo cybersecurity armadillo logo" class="mx-auto mb-6 w-36 h-auto" />
   </header>
-
   <!-- Navigation -->
-  <nav class="bg-gray-800 py-3 rounded-md mb-8 max-w-xl mx-auto">
+  <nav class="bg-armadilloGray py-3 rounded-md mb-8 max-w-xl mx-auto">
     <div class="flex justify-between">
-      <a href="/index.html" class="text-teal-400 font-semibold hover:underline px-3">Home</a>
-      <a href="/services.html" class="text-teal-400 font-semibold hover:underline px-3">Services</a>
-      <a href="/about.html" class="text-teal-400 font-semibold hover:underline px-3">About</a>
-      <a href="/blog.html" class="text-teal-400 font-semibold hover:underline px-3">Blog</a>
-      <a href="/contact.html" class="text-teal-400 font-semibold hover:underline px-3">Contact</a>
+      <a href="/index.html" class="text-oliveGreen font-semibold hover:underline px-3">Home</a>
+      <a href="/services.html" class="text-oliveGreen font-semibold hover:underline px-3">Services</a>
+      <a href="/about.html" class="text-oliveGreen font-semibold hover:underline px-3">About</a>
+      <a href="/blog.html" class="text-oliveGreen font-semibold hover:underline px-3">Blog</a>
+      <a href="/contact.html" class="text-oliveGreen font-semibold hover:underline px-3">Contact</a>
     </div>
   </nav>
-
   <!-- Main Content -->
   <main class="flex-grow max-w-3xl mx-auto px-6 py-12">
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8 text-gray-300">
-      <h1 class="text-3xl font-extrabold text-teal-400 mb-6">Our Commitment</h1>
-
+    <section class="bg-armadilloGray rounded-lg shadow-lg p-8 text-armadilloGray">
+      <h1 class="text-3xl font-extrabold text-oliveGreen mb-6">Our Commitment</h1>
       <p class="mb-6">
         At Iron Dillo Cybersecurity, integrity and transparency guide everything we do. As a sole proprietor, I provide personalized cybersecurity consulting with your best interests in mind.
       </p>
-
       <ul class="list-disc list-inside space-y-4 mb-6">
         <li><strong>Operating Status:</strong> I currently operate as an individual consultant and am working toward forming a registered business entity.</li>
         <li><strong>Client Consent:</strong> No security assessments or testing will be performed without your explicit permission.</li>
@@ -55,19 +54,15 @@
         <li><strong>Billing Transparency:</strong> All fees and deliverables will be clearly outlined in advance and invoiced accurately.</li>
         <li><strong>Legal Compliance:</strong> All work follows applicable laws and ethical standards in cybersecurity consulting.</li>
       </ul>
-
       <p>
         Thank you for trusting Iron Dillo Cybersecurity to help protect your digital assets.
-      </p>
     </section>
   </main>
-
   <!-- Footer -->
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 mt-auto text-sm max-w-3xl mx-auto rounded-md">
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 mt-auto text-sm max-w-3xl mx-auto rounded-md">
     &copy; 2025 Iron Dillo. All rights reserved. | Veteran-Owned | 
-    <a href="/privacy.html" class="hover:underline text-teal-400">Privacy</a> | 
-    <a href="/terms.html" class="hover:underline text-teal-400">Terms</a>
+    <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> | 
+    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
   </footer>
-
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -6,6 +6,7 @@
 <link rel="preconnect" href="https://cdn.tailwindcss.com">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
@@ -18,34 +19,33 @@
   
   <!-- Tailwind CSS CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
-  
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
   <!-- Google reCAPTCHA v2 -->
   <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 </head>
-<body class="bg-gray-900 text-gray-100 min-h-screen flex flex-col font-sans">
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
 
   <!-- Header -->
   <header class="text-center pt-8 max-w-3xl mx-auto">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo cybersecurity logo" class="mx-auto mb-6 w-36 h-auto" />
   </header>
-
   <!-- Navigation -->
-  <nav class="bg-gray-800 py-3 rounded-md mb-8 max-w-xl mx-auto">
+  <nav class="bg-armadilloGray py-3 rounded-md mb-8 max-w-xl mx-auto">
     <div class="flex justify-between">
-      <a href="/index.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Home</a>
-      <a href="/services.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Services</a>
-      <a href="/about.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">About</a>
-      <a href="/contact.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Contact</a>
+      <a href="/index.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Home</a>
+      <a href="/services.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Services</a>
+      <a href="/about.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">About</a>
+      <a href="/contact.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Contact</a>
     </div>
   </nav>
-
   <!-- Main Contact Form -->
-  <main class="flex-grow max-w-xl w-full bg-gray-800 rounded-lg p-8 shadow-lg mx-auto">
-    <h1 class="text-4xl font-extrabold text-teal-400 mb-6 text-center">Contact Iron Dillo</h1>
-    <p class="text-gray-300 mb-8 text-center">
+  <main class="flex-grow max-w-xl w-full bg-armadilloGray rounded-lg p-8 shadow-lg mx-auto">
+    <h1 class="text-4xl font-extrabold text-oliveGreen mb-6 text-center">Contact Iron Dillo</h1>
+    <p class="text-armadilloGray mb-8 text-center">
       Have a cybersecurity question? Want to schedule a consult? Fill out the form below and I’ll respond as soon as possible.
     </p>
-
     <form
       id="contact-form"
       action="https://formspree.io/f/xldnbpdg"
@@ -58,67 +58,48 @@
         <label for="gotcha">Leave this empty</label>
         <input type="text" name="_gotcha" id="gotcha" autocomplete="off" />
       </div>
-
       <div>
-        <label for="name" class="block mb-2 font-semibold text-teal-400">Your Name</label>
+        <label for="name" class="block mb-2 font-semibold text-oliveGreen">Your Name</label>
         <input
           type="text"
           name="name"
           id="name"
           required
-          class="w-full p-3 rounded bg-gray-900 border border-gray-700 text-gray-100 focus:outline-none focus:ring-2 focus:ring-teal-400"
+          class="w-full p-3 rounded bg-armadilloBlack border border-armadilloGray text-offWhite focus:outline-none focus:ring-2 focus:ring-oliveGreen"
           placeholder="Jane Doe"
           autocomplete="name"
         />
-      </div>
-
-      <div>
-        <label for="email" class="block mb-2 font-semibold text-teal-400">Your Email</label>
-        <input
+        <label for="email" class="block mb-2 font-semibold text-oliveGreen">Your Email</label>
           type="email"
           name="_replyto"
           id="email"
-          required
-          class="w-full p-3 rounded bg-gray-900 border border-gray-700 text-gray-100 focus:outline-none focus:ring-2 focus:ring-teal-400"
           placeholder="you@example.com"
           autocomplete="email"
-        />
-      </div>
-
-      <div>
-        <label for="message" class="block mb-2 font-semibold text-teal-400">Message</label>
+        <label for="message" class="block mb-2 font-semibold text-oliveGreen">Message</label>
         <textarea
           name="message"
           id="message"
           rows="5"
-          required
-          class="w-full p-3 rounded bg-gray-900 border border-gray-700 text-gray-100 focus:outline-none focus:ring-2 focus:ring-teal-400"
           placeholder="Write your message here..."
         ></textarea>
-      </div>
-
       <!-- reCAPTCHA -->
       <div class="g-recaptcha" data-sitekey="6LdCtosrAAAAAGddw60skAwbV91b2UmEAuLaSLYb"></div>
-
       <!-- Optional Redirect -->
       <input type="hidden" name="_next" value="/thank-you.html" />
-
       <button
         type="submit"
-        class="w-full mt-4 bg-teal-400 text-gray-900 font-extrabold py-3 rounded hover:bg-teal-500 transition-colors duration-200"
+        class="w-full mt-4 bg-oliveGreen text-armadilloBlack font-extrabold py-3 rounded hover:bg-oliveGreen transition-colors duration-200"
       >
         Send Message
       </button>
     </form>
   </main>
-
   <!-- Footer -->
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 mt-8 text-sm max-w-3xl mx-auto rounded-md">
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 mt-8 text-sm max-w-3xl mx-auto rounded-md">
     &copy; 2025 Iron Dillo. All rights reserved. | Veteran-Owned | 
-    <a href="/privacy.html" class="hover:underline text-teal-400">Privacy</a> | 
-    <a href="/terms.html" class="hover:underline text-teal-400">Terms</a>
+    <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> | 
+    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
   </footer>
-
   <script>
     // Prevent form submit if reCAPTCHA not verified
     function onSubmit(event) {

--- a/index.html
+++ b/index.html
@@ -7,17 +7,16 @@
 <script>
   // Set this to false to disable maintenance mode
   const maintenanceMode = true;
-
   if (maintenanceMode) {
     window.location.href = "maintenance.html";
   }
 </script>
-
 <meta name="description" content="Iron Dillo Cybersecurity provides honest, hands-on protection for individuals, small businesses, and rural operations. Veteran-owned and mission-driven, offering remote diagnostics, documentation, and guidance you can trust." />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link rel="preconnect" href="https://cdn.tailwindcss.com">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
@@ -27,6 +26,7 @@
 <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
 <link rel="icon" href="/assets/favicon.png" />
 <script src="https://cdn.tailwindcss.com"></script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
 <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 <style>
 @keyframes fadeIn {
@@ -35,90 +35,70 @@ to { opacity: 1; }
 }
 .fade-in {
 animation: fadeIn 1.2s ease-out both;
-}
 </style>
 </head>
-<body class="flex flex-col min-h-screen bg-gray-900 text-gray-100 font-sans">
-
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
 <!-- Header with logo, title, and navigation -->
 <header class="p-8 text-center max-w-3xl mx-auto fade-in">
   <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo logo" class="mx-auto mb-6 w-32 h-auto" />
-  <h1 class="text-4xl font-extrabold text-teal-400 mb-4">
+  <h1 class="text-4xl font-extrabold text-oliveGreen mb-4">
     Iron Dillo Cybersecurity
   </h1>
-
   <!-- Navigation -->
-  <nav class="bg-gray-800 py-3 rounded-md mb-8 max-w-xl mx-auto">
+  <nav class="bg-armadilloGray py-3 rounded-md mb-8 max-w-xl mx-auto">
     <div class="flex justify-between flex-wrap gap-2 px-4">
-      <a href="/index.html" class="text-teal-400 font-semibold hover:underline tracking-wide uppercase">Home</a>
-      <a href="/services.html" class="text-teal-400 font-semibold hover:underline tracking-wide uppercase">Services</a>
-      <a href="/about.html" class="text-teal-400 font-semibold hover:underline tracking-wide uppercase">About</a>
-      <a href="/contact.html" class="text-teal-400 font-semibold hover:underline tracking-wide uppercase">Contact</a>
+      <a href="/index.html" class="text-oliveGreen font-semibold hover:underline tracking-wide uppercase">Home</a>
+      <a href="/services.html" class="text-oliveGreen font-semibold hover:underline tracking-wide uppercase">Services</a>
+      <a href="/about.html" class="text-oliveGreen font-semibold hover:underline tracking-wide uppercase">About</a>
+      <a href="/contact.html" class="text-oliveGreen font-semibold hover:underline tracking-wide uppercase">Contact</a>
     </div>
   </nav>
-
-  <p class="text-lg leading-relaxed max-w-xl mx-auto text-gray-300">
+  <p class="text-lg leading-relaxed max-w-xl mx-auto text-armadilloGray">
     <span class="block mb-2">
-      <span class="text-teal-400 font-medium">Iron Dillo Cybersecurity</span> delivers protection for
+      <span class="text-oliveGreen font-medium">Iron Dillo Cybersecurity</span> delivers protection for
       <span class="font-semibold text-white">individuals</span>,
       <span class="font-semibold text-white">small businesses</span>, and
       <span class="font-semibold text-white">rural operations</span> including farms, ranches, and independent shops.
     </span>
     <span class="block mb-4">
-      Founded by a <span class="text-teal-400 font-medium">U.S. Army veteran</span> with a Master’s in Cybersecurity,
+      Founded by a <span class="text-oliveGreen font-medium">U.S. Army veteran</span> with a Master’s in Cybersecurity,
       Iron Dillo provides remote diagnostics, documentation, and guidance you can <span class="font-semibold text-white">trust</span>.
-    </span>
   </p>
-
   <div class="mt-4 flex flex-wrap gap-4 justify-center">
     <a href="/contact.html"
-       class="inline-block bg-teal-500 text-white px-6 py-3 rounded-lg shadow-lg hover:bg-teal-600 transition">
+       class="inline-block bg-oliveGreen text-white px-6 py-3 rounded-lg shadow-lg hover:bg-oliveDark transition">
        Schedule Your $199 Security Check
     </a>
     <a href="/lindale-tyler-cybersecurity.html"
-       class="inline-block bg-gray-700 text-teal-400 px-6 py-3 rounded-lg shadow-lg hover:bg-gray-600 transition">
+       class="inline-block bg-armadilloGray text-oliveGreen px-6 py-3 rounded-lg shadow-lg hover:bg-armadilloBlack transition">
        Lindale & Tyler Cybersecurity
-    </a>
   </div>
 </header>
-
 <!-- Social icons -->
 <section class="fade-in max-w-3xl mx-auto mb-8 text-center">
-  <p class="text-teal-400 font-semibold mb-2">Connect with me</p>
+  <p class="text-oliveGreen font-semibold mb-2">Connect with me</p>
   <div class="inline-flex justify-center space-x-10">
     <!-- GitHub -->
-    <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" target="_blank" aria-label="GitHub" class="hover:scale-110 transition-transform duration-300 text-teal-400 hover:text-white">
+    <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" target="_blank" aria-label="GitHub" class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-white">
       <svg xmlns="http://www.w3.org/2000/svg" class="w-9 h-9" viewBox="0 0 24 24" fill="currentColor">
         <path d="M12 0.5C5.73 0.5.5 5.73.5 12.02c0 5.1 3.29 9.42 7.86 10.96.58.1.79-.25.79-.56v-2.2c-3.2.7-3.87-1.54-3.87-1.54-.53-1.35-1.3-1.71-1.3-1.71-1.06-.73.08-.72.08-.72 1.17.08 1.79 1.2 1.79 1.2 1.04 1.78 2.73 1.27 3.4.97.1-.75.4-1.27.72-1.56-2.56-.3-5.26-1.28-5.26-5.7 0-1.26.45-2.3 1.2-3.12-.12-.3-.52-1.52.11-3.17 0 0 .97-.31 3.18 1.2a11.07 11.07 0 0 1 2.9-.39c.99 0 1.98.13 2.9.39 2.21-1.51 3.18-1.2 3.18-1.2.63 1.65.24 2.87.12 3.17.75.82 1.2 1.86 1.2 3.12 0 4.43-2.7 5.4-5.27 5.7.41.35.77 1.04.77 2.1v3.12c0 .31.21.67.8.56A10.5 10.5 0 0 0 23.5 12C23.5 5.73 18.27.5 12 .5Z"/>
       </svg>
-    </a>
     <!-- Facebook -->
-    <a href="https://www.facebook.com/profile.php?id=61578181152347" target="_blank" aria-label="Facebook" class="hover:scale-110 transition-transform duration-300 text-teal-400 hover:text-white">
-      <svg xmlns="http://www.w3.org/2000/svg" class="w-9 h-9" viewBox="0 0 24 24" fill="currentColor">
+    <a href="https://www.facebook.com/profile.php?id=61578181152347" target="_blank" aria-label="Facebook" class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-white">
         <path d="M22.675 0h-21.35C.6 0 0 .6 0 1.342v21.316C0 23.4.6 24 1.325 24h11.494v-9.294H9.692v-3.622h3.127V8.413c0-3.1 1.893-4.788 4.659-4.788 1.325 0 2.466.099 2.797.143v3.24l-1.918.001c-1.504 0-1.796.716-1.796 1.765v2.315h3.59l-.467 3.622h-3.123V24h6.116C23.4 24 24 23.4 24 22.675V1.342C24 .6 23.4 0 22.675 0z"/>
-      </svg>
-    </a>
     <!-- LinkedIn -->
-    <a href="https://www.linkedin.com/in/kristophermccoy" target="_blank" aria-label="LinkedIn" class="hover:scale-110 transition-transform duration-300 text-teal-400 hover:text-white">
-      <svg xmlns="http://www.w3.org/2000/svg" class="w-9 h-9" viewBox="0 0 24 24" fill="currentColor">
+    <a href="https://www.linkedin.com/in/kristophermccoy" target="_blank" aria-label="LinkedIn" class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-white">
         <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.025-3.037-1.852-3.037-1.854 0-2.137 1.445-2.137 2.939v5.667H9.351V9h3.414v1.561h.049c.476-.9 1.637-1.852 3.37-1.852 3.604 0 4.271 2.37 4.271 5.452v6.291zM5.337 7.433c-1.144 0-2.07-.927-2.07-2.07 0-1.144.926-2.07 2.07-2.07 1.143 0 2.07.926 2.07 2.07 0 1.143-.927 2.07-2.07 2.07zm1.777 13.019H3.56V9h3.554v11.452zM22.225 0H1.771C.792 0 0 .792 0 1.77v20.451C0 23.207.792 24 1.77 24h20.451C23.208 24 24 23.207 24 22.222V1.77C24 .792 23.208 0 22.225 0z"/>
-      </svg>
-    </a>
-  </div>
 </section>
-
 <!-- Footer -->
-<footer class="bg-gray-800 text-gray-500 text-center p-6 mt-auto text-sm max-w-3xl mx-auto rounded-md">
+<footer class="bg-armadilloGray text-armadilloGray text-center p-6 mt-auto text-sm max-w-3xl mx-auto rounded-md">
   &copy; 2025 Iron Dillo. All rights reserved.
-  <p class="mt-4 text-gray-400 italic">
+  <p class="mt-4 text-armadilloGray italic">
     Trusted by East Texas businesses. Veteran-owned. Mission-driven.
-  </p>
   <div class="mt-2 space-x-4">
     <a href="/privacy.html" class="hover:underline">Privacy</a>
     <a href="/terms.html" class="hover:underline">Terms</a>
     <a href="/commitment.html" class="hover:underline">Our Commitment</a>
-  </div>
 </footer>
-
 </body>
 </html>

--- a/lindale-tyler-cybersecurity.html
+++ b/lindale-tyler-cybersecurity.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://cdn.tailwindcss.com">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
   <!-- 🛡 Security Headers -->
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
@@ -25,75 +26,62 @@
   <meta property="og:url" content="https://irondillo.com/lindale-tyler-cybersecurity.html" />
   <meta name="twitter:card" content="summary_large_image" />
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
   <style>
     @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
     .fade-in { animation: fadeIn 1s ease-out both; }
   </style>
 </head>
-<body class="flex flex-col min-h-screen bg-gray-900 text-gray-100 font-sans">
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
 
   <!-- Logo Header -->
   <header class="text-center pt-8 max-w-3xl mx-auto fade-in">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo cybersecurity logo" class="mx-auto mb-6 w-36 h-auto" />
   </header>
-
   <!-- Navigation -->
-  <nav class="bg-gray-800 py-3 rounded-md mb-8 max-w-xl mx-auto fade-in">
+  <nav class="bg-armadilloGray py-3 rounded-md mb-8 max-w-xl mx-auto fade-in">
     <div class="flex justify-between">
-      <a href="/index.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Home</a>
-      <a href="/services.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Services</a>
-      <a href="/about.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">About</a>
-      <a href="/contact.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Contact</a>
+      <a href="/index.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Home</a>
+      <a href="/services.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Services</a>
+      <a href="/about.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">About</a>
+      <a href="/contact.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Contact</a>
     </div>
   </nav>
-
   <main class="flex-grow max-w-3xl mx-auto px-6 py-12 space-y-12 fade-in">
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8 text-center">
-      <h1 class="text-3xl font-bold text-teal-400 mb-4">Lindale & Tyler Cybersecurity</h1>
-      <p class="text-gray-300 leading-relaxed">
+    <section class="bg-armadilloGray rounded-lg shadow-lg p-8 text-center">
+      <h1 class="text-3xl font-bold text-oliveGreen mb-4">Lindale & Tyler Cybersecurity</h1>
+      <p class="text-armadilloGray leading-relaxed">
         Based in Lindale, Iron Dillo Cybersecurity proudly serves nearby Tyler and the surrounding East Texas region.
         I provide hands-on cyber defense, risk assessments, and security training tailored to local small businesses.
       </p>
     </section>
-
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8">
-      <h2 class="text-2xl font-semibold text-teal-300 mb-4">Why Local Cyber Defense Matters</h2>
-      <p class="text-gray-300 leading-relaxed">
+    <section class="bg-armadilloGray rounded-lg shadow-lg p-8">
+      <h2 class="text-2xl font-semibold text-oliveGreen mb-4">Why Local Cyber Defense Matters</h2>
         From ransomware to phishing, Lindale and Tyler businesses face the same
         dangers of any large metro area. Working with a nearby partner means quicker response times and a better
         understanding of your unique challenges.
-      </p>
-    </section>
-
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8">
-      <h2 class="text-2xl font-semibold text-teal-300 mb-4">Services for East Texas</h2>
-      <p class="text-gray-300 leading-relaxed">
+      <h2 class="text-2xl font-semibold text-oliveGreen mb-4">Services for East Texas</h2>
         Whether you need a one-time security audit or ongoing support, I offer practical solutions:
-      </p>
-      <ul class="list-disc list-inside text-gray-300 mt-4 space-y-2">
+      <ul class="list-disc list-inside text-armadilloGray mt-4 space-y-2">
         <li>Security consultations and risk assessments</li>
         <li>Policy development and incident response planning</li>
         <li>Vulnerability scanning and remediation guidance</li>
         <li>Employee cybersecurity awareness training</li>
       </ul>
-    </section>
-
-    <section class="bg-gray-900 py-12 text-center">
+    <section class="bg-armadilloBlack py-12 text-center">
       <h2 class="text-2xl font-bold text-white mb-4">Protect Your Lindale or Tyler Business</h2>
-      <p class="text-gray-300 max-w-xl mx-auto">
+      <p class="text-armadilloGray max-w-xl mx-auto">
         Let's secure your operations so you can focus on growing your business. Get in touch for a free consultation
         and find out how Iron Dillo can defend your organization.
-      </p>
-      <a href="/contact.html" class="mt-6 inline-block bg-teal-500 text-white px-6 py-3 rounded-lg shadow-lg hover:bg-teal-600 transition">Contact Me Today</a>
-    </section>
+      <a href="/contact.html" class="mt-6 inline-block bg-oliveGreen text-white px-6 py-3 rounded-lg shadow-lg hover:bg-oliveDark transition">Contact Me Today</a>
   </main>
-
   <!-- Footer -->
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 mt-auto text-sm max-w-3xl mx-auto rounded-md fade-in">
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 mt-auto text-sm max-w-3xl mx-auto rounded-md fade-in">
     &copy; 2025 Iron Dillo. All rights reserved. | Veteran-Owned |
-    <a href="/privacy.html" class="hover:underline text-teal-400">Privacy</a> |
-    <a href="/terms.html" class="hover:underline text-teal-400">Terms</a>
+    <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> |
+    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
   </footer>
-
 </body>
 </html>

--- a/maintenance.html
+++ b/maintenance.html
@@ -6,6 +6,7 @@
   <link rel="preconnect" href="https://cdn.tailwindcss.com">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 
   <!-- 🛡 Security Headers -->
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
@@ -15,9 +16,11 @@
   <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), microphone=()">
   <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.png" />
-
   <title>Iron Dillo | Cyberstasis Mode</title>
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
   <style>
     @keyframes matrixScroll {
       0% { transform: translateY(100%); opacity: 0; }
@@ -32,11 +35,9 @@
       font-family: monospace;
       text-shadow: 0 0 5px #00ff00;
       opacity: 0.8;
-    }
   </style>
 </head>
-<body class="relative h-screen w-screen bg-black text-white overflow-hidden">
-
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
   <!-- Scrolling Matrix Text -->
   <div class="absolute z-20 w-full h-full flex flex-col items-center justify-center space-y-4 overflow-hidden">
     <div class="h-full w-64 relative">
@@ -51,7 +52,6 @@
       </div>
     </div>
   </div>
-
   <!-- Center Message -->
   <div class="absolute z-30 inset-0 flex items-center justify-center">
     <div class="text-center px-6 py-4 bg-black bg-opacity-30 rounded-2xl shadow-lg">
@@ -60,8 +60,5 @@
         Iron Dillo is currently in maintenance mode.<br />
         Please check back soon.
       </p>
-    </div>
-  </div>
-
 </body>
 </html>

--- a/posts/closing-ports-backdoors.html
+++ b/posts/closing-ports-backdoors.html
@@ -8,6 +8,7 @@
 <link rel="preconnect" href="https://cdn.tailwindcss.com">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
@@ -18,38 +19,38 @@
   <link rel="icon" href="/assets/favicon.ico" />
   <link rel="canonical" href="https://irondillo.com/posts/closing-ports-backdoors.html" />
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
 </head>
 
-<body class="bg-gray-900 text-gray-100 font-sans flex flex-col min-h-screen">
-
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
   <!-- Logo + Nav -->
   <header class="text-center py-8 max-w-3xl mx-auto fade-in">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo Logo" class="mx-auto w-32 mb-6" />
-    <h1 class="text-4xl font-extrabold text-teal-400 mb-4">Are Open Ports a Backdoor?</h1>
-    <nav class="bg-gray-800 py-3 rounded-md mb-6 inline-block w-full max-w-md mx-auto">
+    <h1 class="text-4xl font-extrabold text-oliveGreen mb-4">Are Open Ports a Backdoor?</h1>
+    <nav class="bg-armadilloGray py-3 rounded-md mb-6 inline-block w-full max-w-md mx-auto">
       <div class="flex justify-center space-x-6">
-        <a href="/index.html" class="text-teal-400 font-semibold hover:underline">Home</a>
-        <a href="/services.html" class="text-teal-400 font-semibold hover:underline">Services</a>
-        <a href="/about.html" class="text-teal-400 font-semibold hover:underline">About</a>
-        <a href="/blog.html" class="text-teal-400 font-semibold hover:underline">Blog</a>
-        <a href="/contact.html" class="text-teal-400 font-semibold hover:underline">Contact</a>
+        <a href="/index.html" class="text-oliveGreen font-semibold hover:underline">Home</a>
+        <a href="/services.html" class="text-oliveGreen font-semibold hover:underline">Services</a>
+        <a href="/about.html" class="text-oliveGreen font-semibold hover:underline">About</a>
+        <a href="/blog.html" class="text-oliveGreen font-semibold hover:underline">Blog</a>
+        <a href="/contact.html" class="text-oliveGreen font-semibold hover:underline">Contact</a>
       </div>
     </nav>
-    <time datetime="2025-06-25" class="text-gray-400 text-xs mb-3 block">Published June 25, 2025</time>
-    <p class="text-gray-400 max-w-xl mx-auto text-base px-4">
+    <time datetime="2025-06-25" class="text-armadilloGray text-xs mb-3 block">Published June 25, 2025</time>
+    <p class="text-armadilloGray max-w-xl mx-auto text-base px-4">
       Open ports are necessary for communication, but they can become dangerous if left exposed. Here's how to tell the difference and lock things down.
     </p>
   </header>
-
   <!-- Main Content -->
   <main class="flex-grow px-6 pb-20 max-w-3xl mx-auto space-y-10">
-
-    <section class="bg-gray-800 p-6 rounded-lg shadow-lg space-y-6">
-      <h2 class="text-2xl text-teal-300 font-bold">What is a Port?</h2>
+    <section class="bg-armadilloGray p-6 rounded-lg shadow-lg space-y-6">
+      <h2 class="text-2xl text-oliveGreen font-bold">What is a Port?</h2>
       <p>
         A port is like a channel for sending or receiving data between your computer and the internet. Each port corresponds to a specific service or protocol.
       </p>
-      <p class="text-sm text-gray-400">Here are a few common ports:</p>
+      <p class="text-sm text-armadilloGray">Here are a few common ports:</p>
       <ul class="list-disc list-inside space-y-1 text-gray-200">
         <li><strong>80</strong> — HTTP (unsecured web traffic)</li>
         <li><strong>443</strong> — HTTPS (secure web traffic)</li>
@@ -57,53 +58,31 @@
         <li><strong>3389</strong> — RDP (remote desktop)</li>
       </ul>
     </section>
-
-    <section class="bg-gray-800 p-6 rounded-lg shadow-lg space-y-6">
-      <h2 class="text-2xl text-teal-300 font-bold">Why Are Open Ports a Risk?</h2>
-      <p>
+      <h2 class="text-2xl text-oliveGreen font-bold">Why Are Open Ports a Risk?</h2>
         If a port is left open to the internet and the service behind it is misconfigured or outdated, attackers can exploit it to gain access to your system.
-      </p>
-      <p>
-        Tools like <code class="bg-gray-700 px-2 py-1 rounded text-sm">Nmap</code> make it easy for attackers to scan the internet for exposed ports. Once they find one, they look for known vulnerabilities or weak configurations.
-      </p>
-    </section>
-
-    <section class="bg-gray-800 p-6 rounded-lg shadow-lg space-y-6">
-      <h2 class="text-2xl text-teal-300 font-bold">How to Check Your Open Ports</h2>
+        Tools like <code class="bg-armadilloGray px-2 py-1 rounded text-sm">Nmap</code> make it easy for attackers to scan the internet for exposed ports. Once they find one, they look for known vulnerabilities or weak configurations.
+      <h2 class="text-2xl text-oliveGreen font-bold">How to Check Your Open Ports</h2>
       <p>Here are some tools you can use to find out what’s open on your network:</p>
       <ul class="list-disc list-inside space-y-2 text-gray-200">
         <li><strong>ShieldsUP!</strong> — Web-based scanner for external ports</li>
         <li><strong>Nmap</strong> — Open-source command-line tool for scanning local and remote systems</li>
         <li><strong>Netstat</strong> — Built-in tool on most systems to view local port usage</li>
-      </ul>
-    </section>
-
-    <section class="bg-gray-800 p-6 rounded-lg shadow-lg space-y-6">
-      <h2 class="text-2xl text-teal-300 font-bold">Best Practices</h2>
-      <ul class="list-disc list-inside space-y-2 text-gray-200">
+      <h2 class="text-2xl text-oliveGreen font-bold">Best Practices</h2>
         <li>Close any ports you don’t actively need</li>
         <li>Use a firewall to control inbound traffic</li>
         <li>Restrict access by IP address when possible</li>
         <li>Keep all software and services patched and up to date</li>
         <li>Use strong authentication for remote access services</li>
-      </ul>
-      <p>
         Every open port increases your attack surface. The goal is to only leave the necessary ones open — and guard them closely.
-      </p>
-    </section>
-
     <div class="text-center">
-      <a href="/blog.html" class="text-teal-400 hover:underline text-sm">&larr; Back to Blog</a>
+      <a href="/blog.html" class="text-oliveGreen hover:underline text-sm">&larr; Back to Blog</a>
     </div>
-
   </main>
-
   <!-- Footer -->
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 text-sm mt-auto max-w-3xl mx-auto rounded-md">
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 text-sm mt-auto max-w-3xl mx-auto rounded-md">
     &copy; 2025 Iron Dillo. All rights reserved. |
-    <a href="/privacy.html" class="hover:underline text-teal-400">Privacy</a> |
-    <a href="/terms.html" class="hover:underline text-teal-400">Terms</a>
+    <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> |
+    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
   </footer>
-
 </body>
 </html>

--- a/posts/free-tools-i-trust.html
+++ b/posts/free-tools-i-trust.html
@@ -11,6 +11,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
 <meta http-equiv="X-Frame-Options" content="DENY">
 <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
@@ -20,66 +21,49 @@
   <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
   <meta name="author" content="Kristopher McCoy">
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
 </head>
-<body class="bg-gray-900 text-gray-100 font-sans leading-relaxed">
-
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
   <!-- Header -->
   <header class="text-center py-10 px-4 max-w-3xl mx-auto">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6">
-    <h1 class="text-4xl font-extrabold text-teal-400 mb-4">Free Tools I Trust (and Why You Should Too)</h1>
-    <time datetime="2025-06-30" class="text-gray-400 text-xs mb-3 block">Published June 30, 2025</time>
-    <p class="text-gray-300 max-w-xl mx-auto">Not every cybersecurity tool needs to come with a price tag—or an agenda. These are the ones I actually use, recommend, and trust to get the job done right.</p>
+    <h1 class="text-4xl font-extrabold text-oliveGreen mb-4">Free Tools I Trust (and Why You Should Too)</h1>
+    <time datetime="2025-06-30" class="text-armadilloGray text-xs mb-3 block">Published June 30, 2025</time>
+    <p class="text-armadilloGray max-w-xl mx-auto">Not every cybersecurity tool needs to come with a price tag—or an agenda. These are the ones I actually use, recommend, and trust to get the job done right.</p>
   </header>
-
   <!-- Main Content -->
   <main class="max-w-3xl mx-auto px-6 space-y-12 pb-24">
-
-    <section class="bg-gray-800 rounded-lg p-6 shadow-lg">
-      <h2 class="text-2xl text-teal-300 font-semibold mb-2">Bitwarden – Password Manager</h2>
-      <p class="mb-2 text-gray-300">If you're still reusing the same passwords—or keeping them in a notebook—it's time to level up. Bitwarden is open-source, zero-knowledge, and works across all your devices.</p>
-      <a href="https://bitwarden.com" target="_blank" class="text-teal-400 underline hover:text-teal-300">bitwarden.com</a>
+    <section class="bg-armadilloGray rounded-lg p-6 shadow-lg">
+      <h2 class="text-2xl text-oliveGreen font-semibold mb-2">Bitwarden – Password Manager</h2>
+      <p class="mb-2 text-armadilloGray">If you're still reusing the same passwords—or keeping them in a notebook—it's time to level up. Bitwarden is open-source, zero-knowledge, and works across all your devices.</p>
+      <a href="https://bitwarden.com" target="_blank" class="text-oliveGreen underline hover:text-oliveDark">bitwarden.com</a>
     </section>
-
-    <section class="bg-gray-800 rounded-lg p-6 shadow-lg">
-      <h2 class="text-2xl text-teal-300 font-semibold mb-2">uBlock Origin – Browser Protection</h2>
-      <p class="mb-2 text-gray-300">This isn’t just an ad blocker—it’s a privacy wall. uBlock Origin filters out trackers, malware scripts, and telemetry so you can browse faster, lighter, and safer.</p>
-      <a href="https://ublockorigin.com" target="_blank" class="text-teal-400 underline hover:text-teal-300">ublockorigin.com</a>
-    </section>
-
-    <section class="bg-gray-800 rounded-lg p-6 shadow-lg">
-      <h2 class="text-2xl text-teal-300 font-semibold mb-2">Have I Been Pwned – Breach Checker</h2>
-      <p class="mb-2 text-gray-300">Your email might already be floating around hacker forums. This tool lets you check if your accounts have been exposed in known breaches—and prompts you to act before it’s too late.</p>
-      <a href="https://haveibeenpwned.com" target="_blank" class="text-teal-400 underline hover:text-teal-300">haveibeenpwned.com</a>
-    </section>
-
-    <section class="bg-gray-800 rounded-lg p-6 shadow-lg">
-      <h2 class="text-2xl text-teal-300 font-semibold mb-2">VirusTotal – File & Link Scanner</h2>
-      <p class="mb-2 text-gray-300">Get a second opinion—actually, get 70. VirusTotal checks suspicious links or files against dozens of antivirus engines before you ever click “open.”</p>
-      <a href="https://www.virustotal.com" target="_blank" class="text-teal-400 underline hover:text-teal-300">virustotal.com</a>
-    </section>
-
-    <section class="bg-gray-800 rounded-lg p-6 shadow-lg">
-      <h2 class="text-2xl text-teal-300 font-semibold mb-2">SimpleLogin – Email Aliases</h2>
-      <p class="mb-2 text-gray-300">Tired of giving your real email to every site? SimpleLogin lets you create masked aliases—so you can sign up, test things out, or block spam without exposing your inbox.</p>
-      <a href="https://simplelogin.io" target="_blank" class="text-teal-400 underline hover:text-teal-300">simplelogin.io</a>
-    </section>
-
-    <section class="text-center pt-8 border-t border-gray-700">
-      <p class="text-lg text-gray-300 mb-4">These aren’t flashy tools. They’re reliable, transparent, and genuinely helpful—just like the kind of cybersecurity Iron Dillo stands for.</p>
-      <p class="italic text-sm text-gray-500">No sponsorships. No kickbacks. Just solid tools I use myself.</p>
-    </section>
-
+      <h2 class="text-2xl text-oliveGreen font-semibold mb-2">uBlock Origin – Browser Protection</h2>
+      <p class="mb-2 text-armadilloGray">This isn’t just an ad blocker—it’s a privacy wall. uBlock Origin filters out trackers, malware scripts, and telemetry so you can browse faster, lighter, and safer.</p>
+      <a href="https://ublockorigin.com" target="_blank" class="text-oliveGreen underline hover:text-oliveDark">ublockorigin.com</a>
+      <h2 class="text-2xl text-oliveGreen font-semibold mb-2">Have I Been Pwned – Breach Checker</h2>
+      <p class="mb-2 text-armadilloGray">Your email might already be floating around hacker forums. This tool lets you check if your accounts have been exposed in known breaches—and prompts you to act before it’s too late.</p>
+      <a href="https://haveibeenpwned.com" target="_blank" class="text-oliveGreen underline hover:text-oliveDark">haveibeenpwned.com</a>
+      <h2 class="text-2xl text-oliveGreen font-semibold mb-2">VirusTotal – File & Link Scanner</h2>
+      <p class="mb-2 text-armadilloGray">Get a second opinion—actually, get 70. VirusTotal checks suspicious links or files against dozens of antivirus engines before you ever click “open.”</p>
+      <a href="https://www.virustotal.com" target="_blank" class="text-oliveGreen underline hover:text-oliveDark">virustotal.com</a>
+      <h2 class="text-2xl text-oliveGreen font-semibold mb-2">SimpleLogin – Email Aliases</h2>
+      <p class="mb-2 text-armadilloGray">Tired of giving your real email to every site? SimpleLogin lets you create masked aliases—so you can sign up, test things out, or block spam without exposing your inbox.</p>
+      <a href="https://simplelogin.io" target="_blank" class="text-oliveGreen underline hover:text-oliveDark">simplelogin.io</a>
+    <section class="text-center pt-8 border-t border-armadilloGray">
+      <p class="text-lg text-armadilloGray mb-4">These aren’t flashy tools. They’re reliable, transparent, and genuinely helpful—just like the kind of cybersecurity Iron Dillo stands for.</p>
+      <p class="italic text-sm text-armadilloGray">No sponsorships. No kickbacks. Just solid tools I use myself.</p>
     <div class="text-center pt-6">
-      <a href="/blog.html" class="text-teal-400 hover:text-teal-300 underline">&larr; Back to Blog</a>
+      <a href="/blog.html" class="text-oliveGreen hover:text-oliveDark underline">&larr; Back to Blog</a>
     </div>
   </main>
-
   <!-- Footer -->
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 text-sm mt-auto">
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 text-sm mt-auto">
     &copy; 2025 Iron Dillo. All rights reserved. |
-    <a href="/privacy.html" class="hover:underline text-teal-400">Privacy</a> |
-    <a href="/terms.html" class="hover:underline text-teal-400">Terms</a>
+    <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> |
+    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
   </footer>
-
 </body>
 </html>

--- a/posts/rural-cybersecurity.html
+++ b/posts/rural-cybersecurity.html
@@ -10,6 +10,7 @@
 <link rel="preconnect" href="https://cdn.tailwindcss.com">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
@@ -26,68 +27,55 @@
   <meta property="og:image" content="https://irondillo.com/assets/irondillo-preview.png">
   <meta property="og:url" content="https://irondillo.com/posts/rural-cybersecurity.html">
   <meta name="twitter:card" content="summary_large_image">
-
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
 </head>
-<body class="bg-gray-900 text-gray-100 font-sans leading-relaxed">
-
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
   <!-- Header -->
   <header class="text-center py-10 px-4 max-w-3xl mx-auto">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6">
-    <h1 class="text-4xl font-extrabold text-teal-400 mb-4">Why Rural Businesses Can’t Ignore Cybersecurity</h1>
-     <time datetime="2025-06-20" class="text-gray-400 text-sm block mb-6">Published June 20, 2025</time>
-    <p class="text-gray-300 max-w-xl mx-auto">Hackers don’t care about your zip code—they care about how easy you are to break into. Let’s fix that.</p>
+    <h1 class="text-4xl font-extrabold text-oliveGreen mb-4">Why Rural Businesses Can’t Ignore Cybersecurity</h1>
+     <time datetime="2025-06-20" class="text-armadilloGray text-sm block mb-6">Published June 20, 2025</time>
+    <p class="text-armadilloGray max-w-xl mx-auto">Hackers don’t care about your zip code—they care about how easy you are to break into. Let’s fix that.</p>
   </header>
-
   <!-- Main Content -->
   <main class="max-w-3xl mx-auto px-6 pb-24 space-y-10">
-
-    <section class="bg-gray-800 rounded-lg p-6 shadow-lg space-y-4">
-      <p>When people think of cyberattacks, they picture major banks, tech giants, or big-city corporations. But that’s not the whole picture. In reality, <span class="text-teal-300 font-semibold">rural businesses are often softer targets</span>.</p>
-
+    <section class="bg-armadilloGray rounded-lg p-6 shadow-lg space-y-4">
+      <p>When people think of cyberattacks, they picture major banks, tech giants, or big-city corporations. But that’s not the whole picture. In reality, <span class="text-oliveGreen font-semibold">rural businesses are often softer targets</span>.</p>
       <p>Why? Because they tend to skip IT budgets, delay updates, and assume hackers won’t care about a local feed store, farm, or small-town clinic. That’s exactly what attackers are counting on.</p>
-
-      <h2 class="text-2xl text-teal-300 font-semibold pt-4">Real Threats to Real People</h2>
-      <ul class="list-disc list-inside text-gray-300 space-y-2 pl-2">
+      <h2 class="text-2xl text-oliveGreen font-semibold pt-4">Real Threats to Real People</h2>
+      <ul class="list-disc list-inside text-armadilloGray space-y-2 pl-2">
         <li>Phishing emails disguised as invoices or delivery notices</li>
         <li>Remote desktop access left open and unprotected</li>
         <li>Point-of-sale (POS) systems with weak or default credentials</li>
         <li>Employees unknowingly clicking bad links or attachments</li>
       </ul>
-
       <p>Hackers automate scans of the entire internet—looking for outdated software, open ports, and exposed logins. If you’re online, you’re on the radar.</p>
-
-      <h2 class="text-2xl text-teal-300 font-semibold pt-4">What You Can Do—Right Now</h2>
-      <p class="text-gray-300">You don’t need a massive budget to be more secure. Start with these basics:</p>
-      <ul class="list-disc list-inside text-gray-300 space-y-2 pl-2">
+      <h2 class="text-2xl text-oliveGreen font-semibold pt-4">What You Can Do—Right Now</h2>
+      <p class="text-armadilloGray">You don’t need a massive budget to be more secure. Start with these basics:</p>
         <li>Use unique, strong passwords (and store them in a password manager)</li>
         <li>Keep your operating systems and software up to date</li>
         <li>Back up critical files—ideally offline or offsite</li>
         <li>Limit who has admin access to sensitive systems</li>
         <li>Train staff to spot phishing and social engineering</li>
-      </ul>
-
       <p>Security doesn’t need to be complicated—it needs to be intentional.</p>
     </section>
-
-    <section class="bg-gray-800 rounded-lg p-6 shadow-lg">
-      <h2 class="text-2xl text-teal-300 font-semibold mb-2">Iron Dillo Is Built for This</h2>
-      <p class="text-gray-300 mb-4">I started Iron Dillo specifically to help <span class="font-semibold text-white">rural businesses and everyday folks</span> take their security seriously—without getting overwhelmed by tech jargon or overpriced solutions.</p>
-      <p class="text-gray-300 mb-2">Need a free checklist, a quick consultation, or a full audit? I'm here. Whether it’s your farm’s network or the local clinic’s email system, it deserves protection.</p>
-      <a href="/contact.html" class="inline-block mt-4 text-teal-400 font-semibold underline hover:text-teal-300">Get in touch—let’s lock it down.</a>
-    </section>
-
+    <section class="bg-armadilloGray rounded-lg p-6 shadow-lg">
+      <h2 class="text-2xl text-oliveGreen font-semibold mb-2">Iron Dillo Is Built for This</h2>
+      <p class="text-armadilloGray mb-4">I started Iron Dillo specifically to help <span class="font-semibold text-white">rural businesses and everyday folks</span> take their security seriously—without getting overwhelmed by tech jargon or overpriced solutions.</p>
+      <p class="text-armadilloGray mb-2">Need a free checklist, a quick consultation, or a full audit? I'm here. Whether it’s your farm’s network or the local clinic’s email system, it deserves protection.</p>
+      <a href="/contact.html" class="inline-block mt-4 text-oliveGreen font-semibold underline hover:text-oliveDark">Get in touch—let’s lock it down.</a>
     <div class="text-center pt-8">
-      <a href="/blog.html" class="text-teal-400 underline hover:text-teal-300">&larr; Back to Blog</a>
+      <a href="/blog.html" class="text-oliveGreen underline hover:text-oliveDark">&larr; Back to Blog</a>
     </div>
   </main>
-
   <!-- Footer -->
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 text-sm mt-auto">
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 text-sm mt-auto">
     &copy; 2025 Iron Dillo. All rights reserved. |
-    <a href="/privacy.html" class="hover:underline text-teal-400">Privacy</a> |
-    <a href="/terms.html" class="hover:underline text-teal-400">Terms</a>
+    <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> |
+    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
   </footer>
-
 </body>
 </html>

--- a/posts/safer-online-now.html
+++ b/posts/safer-online-now.html
@@ -11,6 +11,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
 <meta http-equiv="X-Frame-Options" content="DENY">
 <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
@@ -25,66 +26,47 @@
   <meta property="og:image" content="https://irondillo.com/assets/irondillo-preview.png">
   <meta property="og:url" content="https://irondillo.com/posts/safer-online-now.html">
   <meta name="twitter:card" content="summary_large_image">
-
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
 </head>
-<body class="bg-gray-900 text-gray-100 font-sans leading-relaxed">
-
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
   <!-- Header -->
   <header class="text-center py-10 px-4 max-w-3xl mx-auto">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6">
-    <h1 class="text-4xl font-extrabold text-teal-400 mb-4">5 Ways to Stay Safer Online Right Now</h1>
-    <time datetime="2025-07-15" class="text-gray-400 text-xs mb-3 block">Published July 15, 2025</time>
-    <p class="text-gray-300 max-w-xl mx-auto">You don’t need to be a tech wizard to defend yourself. Just build good habits—fast, simple, and Iron Dillo–approved.</p>
+    <h1 class="text-4xl font-extrabold text-oliveGreen mb-4">5 Ways to Stay Safer Online Right Now</h1>
+    <time datetime="2025-07-15" class="text-armadilloGray text-xs mb-3 block">Published July 15, 2025</time>
+    <p class="text-armadilloGray max-w-xl mx-auto">You don’t need to be a tech wizard to defend yourself. Just build good habits—fast, simple, and Iron Dillo–approved.</p>
   </header>
-
   <!-- Main Content -->
   <main class="max-w-3xl mx-auto px-6 pb-24 space-y-10">
-
-    <section class="bg-gray-800 rounded-lg p-6 shadow-lg space-y-6">
+    <section class="bg-armadilloGray rounded-lg p-6 shadow-lg space-y-6">
       <div>
-        <h2 class="text-2xl text-teal-300 font-semibold mb-2">1. Stop Reusing Passwords</h2>
-        <p>Each account needs its own strong, unique password. A breach at one site shouldn't compromise the rest of your digital life. Use a password manager like <a href="https://bitwarden.com" class="text-teal-400 underline hover:text-teal-300" target="_blank">Bitwarden</a> or <a href="https://keepass.info" class="text-teal-400 underline hover:text-teal-300" target="_blank">KeePass</a> to do the heavy lifting.</p>
+        <h2 class="text-2xl text-oliveGreen font-semibold mb-2">1. Stop Reusing Passwords</h2>
+        <p>Each account needs its own strong, unique password. A breach at one site shouldn't compromise the rest of your digital life. Use a password manager like <a href="https://bitwarden.com" class="text-oliveGreen underline hover:text-oliveDark" target="_blank">Bitwarden</a> or <a href="https://keepass.info" class="text-oliveGreen underline hover:text-oliveDark" target="_blank">KeePass</a> to do the heavy lifting.</p>
       </div>
-
-      <div>
-        <h2 class="text-2xl text-teal-300 font-semibold mb-2">2. Turn On Two-Factor Authentication (2FA)</h2>
-        <p>Even if someone guesses your password, 2FA can stop them cold. Opt for app-based methods like <a href="https://authy.com" class="text-teal-400 underline hover:text-teal-300" target="_blank">Authy</a> or Google Authenticator instead of SMS when possible. It’s one of the simplest ways to keep intruders out.</p>
-      </div>
-
-      <div>
-        <h2 class="text-2xl text-teal-300 font-semibold mb-2">3. Update Your Devices</h2>
+        <h2 class="text-2xl text-oliveGreen font-semibold mb-2">2. Turn On Two-Factor Authentication (2FA)</h2>
+        <p>Even if someone guesses your password, 2FA can stop them cold. Opt for app-based methods like <a href="https://authy.com" class="text-oliveGreen underline hover:text-oliveDark" target="_blank">Authy</a> or Google Authenticator instead of SMS when possible. It’s one of the simplest ways to keep intruders out.</p>
+        <h2 class="text-2xl text-oliveGreen font-semibold mb-2">3. Update Your Devices</h2>
         <p>Most successful attacks exploit known vulnerabilities that were patched months (or years) ago. Enable auto-updates on your devices, software, apps, and browsers. Staying updated closes doors before attackers can walk through them.</p>
-      </div>
-
-      <div>
-        <h2 class="text-2xl text-teal-300 font-semibold mb-2">4. Pause Before Clicking</h2>
+        <h2 class="text-2xl text-oliveGreen font-semibold mb-2">4. Pause Before Clicking</h2>
         <p>Phishing remains the #1 way people get compromised. Don’t click on strange links or download unexpected files—especially from “urgent” emails or texts. Hover over links, verify senders, and when in doubt, don’t click.</p>
-      </div>
-
-      <div>
-        <h2 class="text-2xl text-teal-300 font-semibold mb-2">5. Don’t Run as Admin by Default</h2>
+        <h2 class="text-2xl text-oliveGreen font-semibold mb-2">5. Don’t Run as Admin by Default</h2>
         <p>Limit your day-to-day account privileges. Using a standard account reduces the damage if something malicious sneaks in. Save admin access for actual admin tasks.</p>
-      </div>
     </section>
-
-    <section class="bg-gray-800 rounded-lg p-6 shadow-lg space-y-4">
-      <p class="text-gray-300">You don’t need to be paranoid—just prepared. These five moves offer major protection without costing you money or time. Think of it as locking the digital doors and windows before you leave the house.</p>
-
-      <a href="/services.html" class="inline-block text-teal-400 underline font-semibold hover:text-teal-300">Need help applying this at home or in your business? Let’s talk.</a>
-    </section>
-
+    <section class="bg-armadilloGray rounded-lg p-6 shadow-lg space-y-4">
+      <p class="text-armadilloGray">You don’t need to be paranoid—just prepared. These five moves offer major protection without costing you money or time. Think of it as locking the digital doors and windows before you leave the house.</p>
+      <a href="/services.html" class="inline-block text-oliveGreen underline font-semibold hover:text-oliveDark">Need help applying this at home or in your business? Let’s talk.</a>
     <div class="text-center pt-8">
-      <a href="/blog.html" class="text-teal-400 underline hover:text-teal-300">&larr; Back to Blog</a>
+      <a href="/blog.html" class="text-oliveGreen underline hover:text-oliveDark">&larr; Back to Blog</a>
     </div>
   </main>
-
   <!-- Footer -->
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 text-sm mt-auto">
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 text-sm mt-auto">
     &copy; 2025 Iron Dillo. All rights reserved. |
-    <a href="/privacy.html" class="hover:underline text-teal-400">Privacy</a> |
-    <a href="/terms.html" class="hover:underline text-teal-400">Terms</a>
+    <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> |
+    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
   </footer>
-
 </body>
 </html>

--- a/posts/tech-support-scam-warning.html
+++ b/posts/tech-support-scam-warning.html
@@ -11,6 +11,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
 <meta http-equiv="X-Frame-Options" content="DENY">
 <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
@@ -25,65 +26,48 @@
   <meta property="og:image" content="https://irondillo.com/assets/irondillo-preview.png" />
   <meta property="og:url" content="https://irondillo.com/posts/tech-support-scam-warning.html" />
   <meta name="twitter:card" content="summary_large_image" />
-  
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
 </head>
-<body class="bg-gray-900 text-gray-100 font-sans leading-relaxed px-6 max-w-3xl mx-auto py-10">
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
 
   <header class="text-center mb-10">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6" />
-    <h1 class="text-4xl font-extrabold text-teal-400 mb-2">How to Tell If That “Tech Support” Call Is a Scam</h1>
-    <time datetime="2025-10-22" class="text-gray-400 text-sm block mb-6">Published July 10, 2025</time>
-    <p class="text-gray-300 max-w-xl mx-auto">
+    <h1 class="text-4xl font-extrabold text-oliveGreen mb-2">How to Tell If That “Tech Support” Call Is a Scam</h1>
+    <time datetime="2025-10-22" class="text-armadilloGray text-sm block mb-6">Published July 10, 2025</time>
+    <p class="text-armadilloGray max-w-xl mx-auto">
       You’re relaxing, minding your business, when the phone rings. It’s “Microsoft” or “Amazon” or “your bank”—and something’s urgent. Suspicious login. Hacked account. Refund needed. They’ll fix it… if you just give them remote access or read off a code.
     </p>
   </header>
-
   <main class="space-y-8">
     <p><strong>🚨 Stop right there.</strong> No legit company cold-calls you to fix a problem you didn’t know about.</p>
     <p>Here’s how to spot the scam—and shut it down:</p>
-
     <section>
-      <h2 class="text-2xl text-teal-300 font-semibold mb-3">1. They Call You</h2>
+      <h2 class="text-2xl text-oliveGreen font-semibold mb-3">1. They Call You</h2>
       <p>Real tech support doesn’t call out of the blue. Ever. If you didn’t initiate contact, assume it’s fake.</p>
     </section>
-
-    <section>
-      <h2 class="text-2xl text-teal-300 font-semibold mb-3">2. They Want Access</h2>
+      <h2 class="text-2xl text-oliveGreen font-semibold mb-3">2. They Want Access</h2>
       <p>If they ask to install software or take over your device, don’t do it. That’s how they plant malware or steal your info.</p>
-    </section>
-
-    <section>
-      <h2 class="text-2xl text-teal-300 font-semibold mb-3">3. They Push Panic</h2>
+      <h2 class="text-2xl text-oliveGreen font-semibold mb-3">3. They Push Panic</h2>
       <p>Scammers want you to act fast so you don’t think. Stay calm. Ask questions. Say you'll call back—and then look up the company yourself.</p>
-    </section>
-
-    <section>
-      <h2 class="text-2xl text-teal-300 font-semibold mb-3">4. They Demand Weird Payment</h2>
+      <h2 class="text-2xl text-oliveGreen font-semibold mb-3">4. They Demand Weird Payment</h2>
       <p>Gift cards? Crypto? Wire transfer? No real business demands payment like that.</p>
-    </section>
-
-    <section>
-      <h2 class="text-2xl text-teal-300 font-semibold mb-3">5. They Sound Official—but Aren’t</h2>
+      <h2 class="text-2xl text-oliveGreen font-semibold mb-3">5. They Sound Official—but Aren’t</h2>
       <p>They might know your name or spoof a legit number. Doesn’t matter. Anyone can fake a caller ID. It’s the request that matters.</p>
-    </section>
-
-    <hr class="border-gray-700" />
-
+    <hr class="border-armadilloGray" />
     <p><strong>Bottom Line:</strong> Hang up. Block the number. Report it if you want—but don’t engage. And definitely don’t feel bad. These scams catch everyone, from college kids to grandmas.</p>
     <p>Your best defense? A healthy dose of skepticism and a refusal to panic.</p>
     <p><strong>Iron Dillo Rule:</strong> If someone calls you about tech problems you didn’t report, it’s a trap.</p>
-
     <div class="text-center mt-10">
-      <a href="/blog.html" class="text-teal-400 underline hover:text-teal-300">&larr; Back to Blog</a>
+      <a href="/blog.html" class="text-oliveGreen underline hover:text-oliveDark">&larr; Back to Blog</a>
     </div>
   </main>
-
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 text-sm mt-16 rounded-md max-w-3xl mx-auto">
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 text-sm mt-16 rounded-md max-w-3xl mx-auto">
     &copy; 2025 Iron Dillo. All rights reserved. |
-    <a href="/privacy.html" class="hover:underline text-teal-400">Privacy</a> |
-    <a href="/terms.html" class="hover:underline text-teal-400">Terms</a>
+    <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> |
+    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
   </footer>
-
 </body>
 </html>

--- a/posts/wordpress-security-basics.html
+++ b/posts/wordpress-security-basics.html
@@ -10,6 +10,7 @@
 <link rel="preconnect" href="https://cdn.tailwindcss.com">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
@@ -26,70 +27,49 @@
   <meta property="og:image" content="https://irondillo.com/assets/irondillo-preview.png" />
   <meta property="og:url" content="https://irondillo.com/posts/wordpress-security-basics.html" />
   <meta name="twitter:card" content="summary_large_image" />
-
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
 </head>
-<body class="bg-gray-900 text-gray-100 font-sans leading-relaxed">
-
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
   <!-- Header -->
   <header class="text-center py-10 px-6 max-w-3xl mx-auto">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo Logo" class="mx-auto w-28 mb-6" />
-    <h1 class="text-4xl font-extrabold text-teal-400 mb-4">Basic WordPress Security for Beginners</h1>
-    <time datetime="2025-07-05" class="text-gray-400 text-sm block mb-6">Published July 5, 2025</time>
-    <p class="text-gray-300 max-w-xl mx-auto">Launching a WordPress site is easy — securing it doesn't have to be complicated. These five practical steps will protect your site from common attacks without needing to be a tech expert.</p>
-    <p class="text-sm text-gray-500 mt-2">Published June 2025 by IronDillo</p>
+    <h1 class="text-4xl font-extrabold text-oliveGreen mb-4">Basic WordPress Security for Beginners</h1>
+    <time datetime="2025-07-05" class="text-armadilloGray text-sm block mb-6">Published July 5, 2025</time>
+    <p class="text-armadilloGray max-w-xl mx-auto">Launching a WordPress site is easy — securing it doesn't have to be complicated. These five practical steps will protect your site from common attacks without needing to be a tech expert.</p>
+    <p class="text-sm text-armadilloGray mt-2">Published June 2025 by IronDillo</p>
   </header>
-
   <!-- Main Content -->
   <main class="max-w-3xl mx-auto px-6 pb-24 space-y-10">
-
-    <section class="bg-gray-800 rounded-lg p-6 shadow-lg space-y-6">
+    <section class="bg-armadilloGray rounded-lg p-6 shadow-lg space-y-6">
       <article>
-        <h2 class="text-2xl text-teal-300 font-semibold mb-2">1. Change the Default <code class="bg-gray-700 px-1 rounded">admin</code> Username</h2>
-        <p>Using <code class="bg-gray-700 px-1 rounded">admin</code> as your WordPress username is one of the most common ways hackers try to brute-force their way in. Change it to something unique and hard to guess. To do this safely, create a new admin user with a strong username and password, then delete the old <code class="bg-gray-700 px-1 rounded">admin</code> account to close this easy attack vector.</p>
+        <h2 class="text-2xl text-oliveGreen font-semibold mb-2">1. Change the Default <code class="bg-armadilloGray px-1 rounded">admin</code> Username</h2>
+        <p>Using <code class="bg-armadilloGray px-1 rounded">admin</code> as your WordPress username is one of the most common ways hackers try to brute-force their way in. Change it to something unique and hard to guess. To do this safely, create a new admin user with a strong username and password, then delete the old <code class="bg-armadilloGray px-1 rounded">admin</code> account to close this easy attack vector.</p>
       </article>
-
-      <article>
-        <h2 class="text-2xl text-teal-300 font-semibold mb-2">2. Use a Trusted Security Plugin</h2>
-        <p>Security plugins like <a href="https://www.wordfence.com" target="_blank" rel="noopener" class="text-teal-400 underline hover:text-teal-300">Wordfence</a> or <a href="https://ithemes.com/security" target="_blank" rel="noopener" class="text-teal-400 underline hover:text-teal-300">iThemes Security</a> add a powerful layer of protection. They can block brute force login attempts, scan for malware, monitor file changes, and notify you about vulnerabilities. They’re easy to install and configure—even if you’re new to WordPress.</p>
-      </article>
-
-      <article>
-        <h2 class="text-2xl text-teal-300 font-semibold mb-2">3. Keep WordPress, Themes, and Plugins Updated</h2>
+        <h2 class="text-2xl text-oliveGreen font-semibold mb-2">2. Use a Trusted Security Plugin</h2>
+        <p>Security plugins like <a href="https://www.wordfence.com" target="_blank" rel="noopener" class="text-oliveGreen underline hover:text-oliveDark">Wordfence</a> or <a href="https://ithemes.com/security" target="_blank" rel="noopener" class="text-oliveGreen underline hover:text-oliveDark">iThemes Security</a> add a powerful layer of protection. They can block brute force login attempts, scan for malware, monitor file changes, and notify you about vulnerabilities. They’re easy to install and configure—even if you’re new to WordPress.</p>
+        <h2 class="text-2xl text-oliveGreen font-semibold mb-2">3. Keep WordPress, Themes, and Plugins Updated</h2>
         <p>Outdated software is the most common cause of WordPress site hacks. Developers regularly release patches that fix security flaws, so keeping your core WordPress files, themes, and plugins up to date is critical. Consider enabling automatic updates or check for updates at least once a week to stay ahead of threats.</p>
-      </article>
-
-      <article>
-        <h2 class="text-2xl text-teal-300 font-semibold mb-2">4. Disable File Editing in the Dashboard</h2>
-        <p>By default, WordPress lets admins edit plugin and theme files directly through the dashboard. This is convenient but risky if an attacker gains access. To disable this, add the following line to your <code class="bg-gray-700 px-1 rounded">wp-config.php</code> file:</p>
-        <pre class="bg-gray-700 rounded p-4 overflow-x-auto text-sm font-mono"><code>define('DISALLOW_FILE_EDIT', true);</code></pre>
+        <h2 class="text-2xl text-oliveGreen font-semibold mb-2">4. Disable File Editing in the Dashboard</h2>
+        <p>By default, WordPress lets admins edit plugin and theme files directly through the dashboard. This is convenient but risky if an attacker gains access. To disable this, add the following line to your <code class="bg-armadilloGray px-1 rounded">wp-config.php</code> file:</p>
+        <pre class="bg-armadilloGray rounded p-4 overflow-x-auto text-sm font-mono"><code>define('DISALLOW_FILE_EDIT', true);</code></pre>
         <p>This simple step closes off a critical attack surface.</p>
-      </article>
-
-      <article>
-        <h2 class="text-2xl text-teal-300 font-semibold mb-2">5. Use Strong Passwords and Enable Two-Factor Authentication (2FA)</h2>
-        <p>Passwords are your first line of defense—make them strong and unique. Password managers like <a href="https://bitwarden.com" target="_blank" rel="noopener" class="text-teal-400 underline hover:text-teal-300">Bitwarden</a> can help generate and store complex passwords easily.</p>
-        <p>For even stronger security, enable 2FA on your admin accounts using apps like <a href="https://authy.com" target="_blank" rel="noopener" class="text-teal-400 underline hover:text-teal-300">Authy</a> or Google Authenticator. This means even if your password is compromised, attackers need your phone to get in.</p>
-      </article>
-
-      <article>
-        <h2 class="text-2xl text-teal-300 font-semibold mb-2">Bonus: Backup Your Site Regularly</h2>
-        <p>Sometimes, despite best efforts, things go wrong. Regular backups ensure you can restore your site quickly after an attack or error. Most hosts offer automatic backups, but you can also use plugins like <a href="https://updraftplus.com" target="_blank" rel="noopener" class="text-teal-400 underline hover:text-teal-300">UpdraftPlus</a> for hassle-free backups to cloud storage.</p>
-      </article>
+        <h2 class="text-2xl text-oliveGreen font-semibold mb-2">5. Use Strong Passwords and Enable Two-Factor Authentication (2FA)</h2>
+        <p>Passwords are your first line of defense—make them strong and unique. Password managers like <a href="https://bitwarden.com" target="_blank" rel="noopener" class="text-oliveGreen underline hover:text-oliveDark">Bitwarden</a> can help generate and store complex passwords easily.</p>
+        <p>For even stronger security, enable 2FA on your admin accounts using apps like <a href="https://authy.com" target="_blank" rel="noopener" class="text-oliveGreen underline hover:text-oliveDark">Authy</a> or Google Authenticator. This means even if your password is compromised, attackers need your phone to get in.</p>
+        <h2 class="text-2xl text-oliveGreen font-semibold mb-2">Bonus: Backup Your Site Regularly</h2>
+        <p>Sometimes, despite best efforts, things go wrong. Regular backups ensure you can restore your site quickly after an attack or error. Most hosts offer automatic backups, but you can also use plugins like <a href="https://updraftplus.com" target="_blank" rel="noopener" class="text-oliveGreen underline hover:text-oliveDark">UpdraftPlus</a> for hassle-free backups to cloud storage.</p>
     </section>
-
-    <section class="bg-gray-800 rounded-lg p-6 shadow-lg">
-      <p class="text-gray-300">Securing your WordPress site is a marathon, not a sprint—but starting with these essential steps puts you way ahead of most site owners. Need help? <a href="/services.html" class="text-teal-400 underline hover:text-teal-300 font-semibold">I offer light diagnostics and setup advice</a> tailored to beginners.</p>
-    </section>
-
+    <section class="bg-armadilloGray rounded-lg p-6 shadow-lg">
+      <p class="text-armadilloGray">Securing your WordPress site is a marathon, not a sprint—but starting with these essential steps puts you way ahead of most site owners. Need help? <a href="/services.html" class="text-oliveGreen underline hover:text-oliveDark font-semibold">I offer light diagnostics and setup advice</a> tailored to beginners.</p>
     <div class="text-center pt-8">
-      <a href="/blog.html" class="text-teal-400 underline hover:text-teal-300">&larr; Back to Blog</a>
+      <a href="/blog.html" class="text-oliveGreen underline hover:text-oliveDark">&larr; Back to Blog</a>
     </div>
   </main>
-
   <!-- Footer -->
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 text-sm mt-auto">
-    &copy; 2025 Iron Dillo. Veteran-Owned | <a href="/privacy.html" class="hover:underline text-teal-400">Privacy</a> | <a href="/terms.html" class="hover:underline text-teal-400">Terms</a> 
-
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 text-sm mt-auto">
+    &copy; 2025 Iron Dillo. Veteran-Owned | <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> | <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a> 
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -8,6 +8,7 @@
 <link rel="preconnect" href="https://cdn.tailwindcss.com">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
@@ -18,67 +19,59 @@
   <link rel="icon" type="image/x-icon" href="/assets/favicon.png" />
   <link rel="canonical" href="https://irondillo.com/privacy.html" />
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
 </head>
 
-<body class="flex flex-col min-h-screen bg-gray-900 text-gray-100 font-sans">
-
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
   <!-- Logo Header -->
   <header class="text-center pt-8">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo cybersecurity armadillo logo" class="mx-auto mb-6 w-36 h-auto" />
   </header>
-
   <!-- Navigation -->
-  <nav class="bg-gray-800 py-3 rounded-md mb-8 max-w-xl mx-auto">
+  <nav class="bg-armadilloGray py-3 rounded-md mb-8 max-w-xl mx-auto">
     <div class="flex justify-between">
-      <a href="/index.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Home</a>
-      <a href="/services.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Services</a>
-      <a href="/about.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">About</a>
-      <a href="/contact.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Contact</a>
+      <a href="/index.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Home</a>
+      <a href="/services.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Services</a>
+      <a href="/about.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">About</a>
+      <a href="/contact.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Contact</a>
     </div>
   </nav>
-
   <!-- Main Content -->
   <main class="flex-grow max-w-3xl mx-auto px-4 sm:px-6 md:px-8 py-12">
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8">
-      <h1 class="text-3xl font-extrabold text-teal-400 mb-4">Privacy Policy</h1>
-      <p class="text-gray-400 mb-4">Effective Date: June 12, 2025</p>
-
-      <p class="text-gray-300 leading-relaxed mb-4">
+    <section class="bg-armadilloGray rounded-lg shadow-lg p-8">
+      <h1 class="text-3xl font-extrabold text-oliveGreen mb-4">Privacy Policy</h1>
+      <p class="text-armadilloGray mb-4">Effective Date: June 12, 2025</p>
+      <p class="text-armadilloGray leading-relaxed mb-4">
         At Iron Dillo Cybersecurity, your privacy comes first. This site is built with privacy as a priority, and we collect the minimum information necessary to provide our services.
       </p>
-
-      <h2 class="text-xl font-bold text-teal-400 mb-2">Information We Do Not Collect</h2>
-      <ul class="list-disc list-inside space-y-2 text-gray-300 mb-4">
+      <h2 class="text-xl font-bold text-oliveGreen mb-2">Information We Do Not Collect</h2>
+      <ul class="list-disc list-inside space-y-2 text-armadilloGray mb-4">
         <li>No cookies</li>
         <li>No tracking scripts</li>
         <li>No third-party advertising</li>
         <li>No analytics tied to your personal identity</li>
       </ul>
-
-      <h2 class="text-xl font-bold text-teal-400 mb-2">Information You Choose to Share</h2>
-      <p class="text-gray-300 mb-4">If you use the contact form, your message is securely sent via Formspree.</p>
-      <p class="text-gray-300 mb-4">This may include your name, email, and the content of your message.</p>
-      <p class="text-gray-300 mb-4">This information is used only to respond to your inquiry and is not stored on Iron Dillo servers.</p>
-
-      <h2 class="text-xl font-bold text-teal-400 mb-2">How We Handle Your Information</h2>
-      <p class="text-gray-300 mb-4">We do not sell, share, or disclose your personal information to third parties.</p>
-      <p class="text-gray-300 mb-4">We implement basic security measures to ensure messages submitted through the contact form remain private.</p>
-
-      <h2 class="text-xl font-bold text-teal-400 mb-2">External Services</h2>
-      <p class="text-gray-300 mb-4">Google Search Console may collect anonymized, aggregated traffic data for site performance monitoring.</p>
-      <p class="text-gray-300 mb-4">This data cannot be used to identify individual visitors.</p>
-
-      <h2 class="text-xl font-bold text-teal-400 mb-2">Your Control</h2>
-      <p class="text-gray-300">If you have questions or concerns about how your information is handled, please contact us using the <a href="/contact.html" class="text-teal-400 underline hover:text-teal-300">Contact Form</a>.</p>
+      <h2 class="text-xl font-bold text-oliveGreen mb-2">Information You Choose to Share</h2>
+      <p class="text-armadilloGray mb-4">If you use the contact form, your message is securely sent via Formspree.</p>
+      <p class="text-armadilloGray mb-4">This may include your name, email, and the content of your message.</p>
+      <p class="text-armadilloGray mb-4">This information is used only to respond to your inquiry and is not stored on Iron Dillo servers.</p>
+      <h2 class="text-xl font-bold text-oliveGreen mb-2">How We Handle Your Information</h2>
+      <p class="text-armadilloGray mb-4">We do not sell, share, or disclose your personal information to third parties.</p>
+      <p class="text-armadilloGray mb-4">We implement basic security measures to ensure messages submitted through the contact form remain private.</p>
+      <h2 class="text-xl font-bold text-oliveGreen mb-2">External Services</h2>
+      <p class="text-armadilloGray mb-4">Google Search Console may collect anonymized, aggregated traffic data for site performance monitoring.</p>
+      <p class="text-armadilloGray mb-4">This data cannot be used to identify individual visitors.</p>
+      <h2 class="text-xl font-bold text-oliveGreen mb-2">Your Control</h2>
+      <p class="text-armadilloGray">If you have questions or concerns about how your information is handled, please contact us using the <a href="/contact.html" class="text-oliveGreen underline hover:text-oliveDark">Contact Form</a>.</p>
     </section>
   </main>
-
   <!-- Footer -->
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 mt-auto text-sm max-w-3xl mx-auto rounded-md">
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 mt-auto text-sm max-w-3xl mx-auto rounded-md">
     &copy; 2025 Iron Dillo. All rights reserved. | Veteran-Owned | 
-    <a href="/privacy.html" aria-current="page" class="hover:underline text-teal-400">Privacy</a> | 
-    <a href="/terms.html" class="hover:underline text-teal-400">Terms</a>
+    <a href="/privacy.html" aria-current="page" class="hover:underline text-oliveGreen">Privacy</a> | 
+    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
   </footer>
-
 </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -8,6 +8,7 @@
 <link rel="preconnect" href="https://cdn.tailwindcss.com">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
@@ -17,78 +18,59 @@
 <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <link rel="icon" type="image/x-icon" href="/assets/favicon.png" />
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
   <style>
     @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
     .fade-in { animation: fadeIn 1s ease-out both; }
   </style>
 </head>
-<body class="flex flex-col min-h-screen bg-gray-900 text-gray-100 font-sans">
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
 
   <!-- Logo Header -->
   <header class="text-center pt-8 max-w-3xl mx-auto fade-in">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo cybersecurity armadillo logo" class="mx-auto mb-6 w-36 h-auto" />
   </header>
-
   <!-- Navigation -->
-  <nav class="bg-gray-800 py-3 rounded-md mb-8 max-w-xl mx-auto fade-in">
+  <nav class="bg-armadilloGray py-3 rounded-md mb-8 max-w-xl mx-auto fade-in">
     <div class="flex justify-between">
-      <a href="/index.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Home</a>
-      <a href="/services.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Services</a>
-      <a href="/about.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">About</a>
-      <a href="/contact.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Contact</a>
+      <a href="/index.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Home</a>
+      <a href="/services.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Services</a>
+      <a href="/about.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">About</a>
+      <a href="/contact.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Contact</a>
     </div>
   </nav>
-
   <main class="flex-grow max-w-3xl mx-auto px-6 py-12 space-y-12 fade-in">
     <!-- Services Sections -->
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8">
-      <h2 class="text-2xl font-semibold text-teal-300 mb-4">Security Consultations &amp; Risk Assessments</h2>
-      <p class="text-gray-300 leading-relaxed">Identify your current vulnerabilities, understand cybersecurity threats in clear language, and receive actionable recommendations to strengthen your systems and protect your data.</p>
+    <section class="bg-armadilloGray rounded-lg shadow-lg p-8">
+      <h2 class="text-2xl font-semibold text-oliveGreen mb-4">Security Consultations &amp; Risk Assessments</h2>
+      <p class="text-armadilloGray leading-relaxed">Identify your current vulnerabilities, understand cybersecurity threats in clear language, and receive actionable recommendations to strengthen your systems and protect your data.</p>
     </section>
-
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8">
-      <h2 class="text-2xl font-semibold text-teal-300 mb-4">Cybersecurity Policy &amp; Documentation Support</h2>
-      <p class="text-gray-300 leading-relaxed">Develop custom cybersecurity policies, standard operating procedures (SOPs), and incident response plans designed specifically for your operations to help you stay prepared and compliant.</p>
-    </section>
-
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8">
-      <h2 class="text-2xl font-semibold text-teal-300 mb-4">Website &amp; Web Presence Security Audits</h2>
-      <p class="text-gray-300 leading-relaxed">Audit your website, online forms, and public-facing content to find vulnerabilities such as cross-site scripting (XSS), misconfigurations, and other common security risks that could expose your business to cyberattacks.</p>
-    </section>
-
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8">
-      <h2 class="text-2xl font-semibold text-teal-300 mb-4">Personal &amp; Small Business Digital Security Training</h2>
-      <p class="text-gray-300 leading-relaxed">One-on-one or small group training sessions covering phishing prevention, password safety, operational security basics, and other essential topics—delivered in straightforward, easy-to-understand language.</p>
-    </section>
-
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8">
-      <h2 class="text-2xl font-semibold text-teal-300 mb-4">Incident Response Guidance &amp; Remediation Assistance</h2>
-      <p class="text-gray-300 leading-relaxed">If you experience a security incident, I’ll guide you through the response process, help identify the scope, and assist with remediation to minimize damage and restore security quickly.</p>
-    </section>
-
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8">
-      <h2 class="text-2xl font-semibold text-teal-300 mb-4">Vulnerability Scanning &amp; Reporting</h2>
-      <p class="text-gray-300 leading-relaxed">Thorough scans of your systems and networks to identify weaknesses, paired with clear, actionable reports outlining findings and recommended fixes.</p>
-    </section>
-
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8">
-      <h2 class="text-2xl font-semibold text-teal-300 mb-4">Secure Configuration of Devices &amp; Networks</h2>
-      <p class="text-gray-300 leading-relaxed">Ensure your devices, routers, and networks are set up with security best practices to reduce risks and protect your digital environment.</p>
-    </section>
-
+      <h2 class="text-2xl font-semibold text-oliveGreen mb-4">Cybersecurity Policy &amp; Documentation Support</h2>
+      <p class="text-armadilloGray leading-relaxed">Develop custom cybersecurity policies, standard operating procedures (SOPs), and incident response plans designed specifically for your operations to help you stay prepared and compliant.</p>
+      <h2 class="text-2xl font-semibold text-oliveGreen mb-4">Website &amp; Web Presence Security Audits</h2>
+      <p class="text-armadilloGray leading-relaxed">Audit your website, online forms, and public-facing content to find vulnerabilities such as cross-site scripting (XSS), misconfigurations, and other common security risks that could expose your business to cyberattacks.</p>
+      <h2 class="text-2xl font-semibold text-oliveGreen mb-4">Personal &amp; Small Business Digital Security Training</h2>
+      <p class="text-armadilloGray leading-relaxed">One-on-one or small group training sessions covering phishing prevention, password safety, operational security basics, and other essential topics—delivered in straightforward, easy-to-understand language.</p>
+      <h2 class="text-2xl font-semibold text-oliveGreen mb-4">Incident Response Guidance &amp; Remediation Assistance</h2>
+      <p class="text-armadilloGray leading-relaxed">If you experience a security incident, I’ll guide you through the response process, help identify the scope, and assist with remediation to minimize damage and restore security quickly.</p>
+      <h2 class="text-2xl font-semibold text-oliveGreen mb-4">Vulnerability Scanning &amp; Reporting</h2>
+      <p class="text-armadilloGray leading-relaxed">Thorough scans of your systems and networks to identify weaknesses, paired with clear, actionable reports outlining findings and recommended fixes.</p>
+      <h2 class="text-2xl font-semibold text-oliveGreen mb-4">Secure Configuration of Devices &amp; Networks</h2>
+      <p class="text-armadilloGray leading-relaxed">Ensure your devices, routers, and networks are set up with security best practices to reduce risks and protect your digital environment.</p>
     <section class="text-center mt-12">
-  <p class="text-teal-400 font-semibold max-w-xl mx-auto">
+  <p class="text-oliveGreen font-semibold max-w-xl mx-auto">
     Need more advanced support? From detailed risk assessments to full remediation assistance,
     pricing is customized to fit your needs.<br />
-    <a href="/contact.html" class="underline hover:text-teal-300">Contact me</a> today for a free consultation and tailored quote.
+    <a href="/contact.html" class="underline hover:text-oliveDark">Contact me</a> today for a free consultation and tailored quote.
   </p>
 </section>
     
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 mt-auto text-sm max-w-3xl mx-auto rounded-md fade-in">
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 mt-auto text-sm max-w-3xl mx-auto rounded-md fade-in">
     &copy; 2025 Iron Dillo. All rights reserved. | Veteran-Owned | 
-    <a href="/privacy.html" class="hover:underline text-teal-400">Privacy</a> | 
-    <a href="/terms.html" class="hover:underline text-teal-400">Terms</a>
+    <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> | 
+    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
   </footer>
-
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -8,6 +8,7 @@
 <link rel="preconnect" href="https://cdn.tailwindcss.com">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
 <!-- 🛡 Security Headers -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
@@ -18,66 +19,58 @@
   <link rel="icon" type="image/x-icon" href="/assets/favicon.png" />
   <link rel="canonical" href="https://irondillo.com/terms.html" />
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
 </head>
-<body class="flex flex-col min-h-screen bg-gray-900 text-gray-100 font-sans">
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
 
   <!-- Logo Header -->
   <header class="text-center pt-8">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="IronDillo cybersecurity armadillo logo" class="mx-auto mb-6 w-36 h-auto" />
-    <h1 class="text-4xl font-extrabold text-teal-400 mb-2">Terms and Conditions</h1>
-    <p class="text-gray-400">Effective Date: 07/29/2025</p>
+    <h1 class="text-4xl font-extrabold text-oliveGreen mb-2">Terms and Conditions</h1>
+    <p class="text-armadilloGray">Effective Date: 07/29/2025</p>
   </header>
-
   <!-- Navigation -->
-<nav class="bg-gray-800 py-3 rounded-md mb-8 max-w-xl mx-auto">
+<nav class="bg-armadilloGray py-3 rounded-md mb-8 max-w-xl mx-auto">
   <div class="flex justify-between">
-    <a href="/index.html" class="text-teal-400 font-semibold hover:underline px-3">Home</a>
-    <a href="/services.html" class="text-teal-400 font-semibold hover:underline px-3">Services</a>
-    <a href="/about.html" class="text-teal-400 font-semibold hover:underline px-3">About</a>
-    <a href="/contact.html" class="text-teal-400 font-semibold hover:underline px-3">Contact</a>
+    <a href="/index.html" class="text-oliveGreen font-semibold hover:underline px-3">Home</a>
+    <a href="/services.html" class="text-oliveGreen font-semibold hover:underline px-3">Services</a>
+    <a href="/about.html" class="text-oliveGreen font-semibold hover:underline px-3">About</a>
+    <a href="/contact.html" class="text-oliveGreen font-semibold hover:underline px-3">Contact</a>
   </div>
 </nav>
-
   <!-- Main Content -->
   <main class="flex-grow max-w-3xl mx-auto px-6 py-8 space-y-8">
-    <section class="bg-gray-800 rounded-lg shadow-lg p-8">
+    <section class="bg-armadilloGray rounded-lg shadow-lg p-8">
       <p class="mb-4">Welcome to Iron Dillo Cybersecurity. This site reflects both our mission to provide plain-English cybersecurity education and our role as a veteran-owned consulting business. By using this site, you agree to the following terms, designed to protect both you and us.</p>
       
-      <h2 class="text-xl font-semibold text-teal-300">1. What We Provide</h2>
-      <ul class="list-disc list-inside space-y-2 text-gray-300">
+      <h2 class="text-xl font-semibold text-oliveGreen">1. What We Provide</h2>
+      <ul class="list-disc list-inside space-y-2 text-armadilloGray">
         <li>Educational content to help individuals and small businesses understand today’s cybersecurity risks</li>
         <li>Professional consulting services, available through formal written agreements, to deliver assessments, recommendations, and tailored security solutions</li>
       </ul>
       <p>Reading content on this site does not create a client relationship. A signed agreement is required for formal consulting services.</p>
-      
-      <h2 class="text-xl font-semibold text-teal-300">2. Our Commitment to Accuracy</h2>
+      <h2 class="text-xl font-semibold text-oliveGreen">2. Our Commitment to Accuracy</h2>
       <p>We work hard to ensure that all content is accurate and relevant. Cybersecurity changes quickly, so while the information here is trustworthy, no single resource can guarantee full protection from every threat. For advice specific to your situation, please contact us for a consulting engagement.</p>
-      
-      <h2 class="text-xl font-semibold text-teal-300">3. Responsible Use of This Site</h2>
+      <h2 class="text-xl font-semibold text-oliveGreen">3. Responsible Use of This Site</h2>
       <p>To keep this site safe, secure, and useful for everyone, we ask that visitors use it responsibly. By accessing Iron Dillo Cybersecurity, you agree not to engage in activities that could harm the site, compromise its security, or misuse the content provided.</p>
-      <ul class="list-disc list-inside space-y-2 text-gray-300">
         <li>Hack, disrupt, or exploit its content or functionality</li>
         <li>Use it for unlawful or fraudulent purposes</li>
         <li>Copy, republish, or misrepresent content without permission</li>
-      </ul>
-      
-      <h2 class="text-xl font-semibold text-teal-300">4. External Links</h2>
+      <h2 class="text-xl font-semibold text-oliveGreen">4. External Links</h2>
       <p>Occasionally we link to outside sites for reference. We do not control or endorse third-party content and cannot guarantee its accuracy or security.</p>
-      
-      <h2 class="text-xl font-semibold text-teal-300">5. Limitation of Liability</h2>
+      <h2 class="text-xl font-semibold text-oliveGreen">5. Limitation of Liability</h2>
       <p>Iron Dillo Cybersecurity is not liable for damages that may result from using or misapplying the educational content on this site. Professional services, when engaged through a written agreement, are governed by their own terms and deliverables.</p>
-      
-      <h2 class="text-xl font-semibold text-teal-300">6. Contact Us</h2>
-      <p>If you’d like to learn more about our consulting services or have any concerns, please reach out through the <a href="/index.html#contact" class="text-teal-400 underline hover:text-teal-300">Contact Form</a> or email us at waldeinsamkeit8213@gmail.com</p>
+      <h2 class="text-xl font-semibold text-oliveGreen">6. Contact Us</h2>
+      <p>If you’d like to learn more about our consulting services or have any concerns, please reach out through the <a href="/index.html#contact" class="text-oliveGreen underline hover:text-oliveDark">Contact Form</a> or email us at waldeinsamkeit8213@gmail.com</p>
     </section>
   </main>
-
   <!-- Footer -->
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 mt-auto text-sm max-w-4xl mx-auto rounded-md">
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 mt-auto text-sm max-w-4xl mx-auto rounded-md">
     &copy; 2025 Iron Dillo. All rights reserved. | Veteran-Owned | 
-    <a href="/privacy.html" class="hover:underline text-teal-400">Privacy</a> | 
-    <a href="/terms.html" class="hover:underline text-teal-400">Terms</a>
+    <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> | 
+    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
   </footer>
-
 </body>
 </html>

--- a/thank-you.html
+++ b/thank-you.html
@@ -6,37 +6,36 @@
   <title>Thank You | Iron Dillo Cybersecurity</title>
   <link rel="icon" type="image/x-icon" href="/assets/favicon.png" />
   <script src="https://cdn.tailwindcss.com"></script>
+<script>
+ tailwind.config = { theme: { extend: { colors: { armadilloBlack: "#1A1A1A", armadilloGray: "#4A4A4A", oliveGreen: "#6B7B3C", oliveDark: "#55622F", offWhite: "#F8F9FA" }, fontFamily: { inter: ["Inter", "sans-serif"] } } } };
+</script>
 </head>
-<body class="bg-gray-900 text-gray-100 min-h-screen flex flex-col font-sans">
+<body class="flex flex-col min-h-screen bg-offWhite text-armadilloGray font-inter">
 
   <!-- Header -->
   <header class="text-center pt-8 max-w-3xl mx-auto">
     <img src="/assets/irondillo-preview.png" alt="IronDillo cybersecurity logo" class="mx-auto mb-6 w-36 h-auto" />
   </header>
-
   <!-- Navigation -->
-  <nav class="bg-gray-800 py-3 rounded-md mb-8 max-w-xl mx-auto">
+  <nav class="bg-armadilloGray py-3 rounded-md mb-8 max-w-xl mx-auto">
     <div class="flex justify-between">
-      <a href="/index.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Home</a>
-      <a href="/services.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Services</a>
-      <a href="/about.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">About</a>
-      <a href="/contact.html" class="text-teal-400 font-semibold hover:underline px-4 tracking-wide uppercase">Contact</a>
+      <a href="/index.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Home</a>
+      <a href="/services.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Services</a>
+      <a href="/about.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">About</a>
+      <a href="/contact.html" class="text-oliveGreen font-semibold hover:underline px-4 tracking-wide uppercase">Contact</a>
     </div>
   </nav>
-
   <!-- Message -->
-  <main class="flex-grow max-w-xl w-full bg-gray-800 rounded-lg p-8 shadow-lg mx-auto text-center">
-    <h1 class="text-4xl font-extrabold text-teal-400 mb-6">Thank You!</h1>
-    <p class="text-gray-300 mb-8">Your message has been successfully sent. I'll get back to you soon.</p>
-    <a href="/index.html" class="text-teal-400 hover:underline">Return to Home</a>
+  <main class="flex-grow max-w-xl w-full bg-armadilloGray rounded-lg p-8 shadow-lg mx-auto text-center">
+    <h1 class="text-4xl font-extrabold text-oliveGreen mb-6">Thank You!</h1>
+    <p class="text-armadilloGray mb-8">Your message has been successfully sent. I'll get back to you soon.</p>
+    <a href="/index.html" class="text-oliveGreen hover:underline">Return to Home</a>
   </main>
-
   <!-- Footer -->
-  <footer class="bg-gray-800 text-gray-500 text-center p-6 mt-8 text-sm max-w-3xl mx-auto rounded-md">
+  <footer class="bg-armadilloGray text-armadilloGray text-center p-6 mt-8 text-sm max-w-3xl mx-auto rounded-md">
     &copy; 2025 Iron Dillo. All rights reserved. | Veteran-Owned |
-    <a href="/privacy.html" class="hover:underline text-teal-400">Privacy</a> |
-    <a href="/terms.html" class="hover:underline text-teal-400">Terms</a>
+    <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> |
+    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
   </footer>
-
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Inter Google Font link
- set custom Tailwind colors via config script
- switch to new brand palette across all pages
- use Inter and off‑white body background sitewide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d02a30c888322924baa6247cd14e9