### PR TITLE
Add phone number contact details to landing and contact pages

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -65,6 +65,14 @@
       Have a cybersecurity question? Want to schedule a consult? Fill out the form below and I’ll respond as soon as possible.
     </p>
 
+    <div class="bg-armadilloBlack text-offWhite rounded-lg p-6 mb-8 text-center shadow-md">
+      <p class="text-lg font-semibold tracking-wide uppercase">Call Direct</p>
+      <a href="tel:19034023814" class="text-3xl font-bold text-oliveGreen hover:text-oliveDark block mt-2">
+        (903) 402-3814
+      </a>
+      <p class="text-sm mt-3 text-offWhite/80">Reach out for immediate support or to start planning your security strategy.</p>
+    </div>
+
     <form
       id="contact-form"
       action="https://formspree.io/f/xldnbpdg"

--- a/index.html
+++ b/index.html
@@ -63,6 +63,14 @@
       <span class="font-semibold text-armadilloBlack">rural operations</span> across East Texas.
       We provide diagnostics, documentation, and guidance you can <span class="font-semibold text-armadilloBlack">trust</span>.
     </p>
+
+    <div class="bg-white border-2 border-oliveGreen rounded-xl py-6 px-4 shadow-lg inline-block">
+      <p class="text-armadilloBlack text-sm uppercase tracking-[0.35em]">Talk To A Real Expert</p>
+      <a href="tel:19034023814" class="block text-4xl font-extrabold text-oliveGreen mt-3">
+        (903) 402-3814
+      </a>
+      <p class="text-armadilloGray mt-2 max-w-xs mx-auto">Call now for immediate cybersecurity support tailored to East Texas.</p>
+    </div>
   </main>
 
   <!-- Split Section with Bluebonnet Image -->


### PR DESCRIPTION
## Summary
- add a prominent call card with (903) 402-3814 on the contact page
- highlight the phone number in the landing hero for quick access to support

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d43d4595648322877ad5ec2cb3827a