### PR TITLE
Add direct contact info to home and contact footers

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -143,10 +143,28 @@
   </main>
 
   <!-- Footer -->
-  <footer class="bg-armadilloBlack text-offWhite text-center p-6 mt-8 text-sm max-w-3xl mx-auto rounded-md">
-    &copy; 2025 Iron Dillo. All rights reserved. | Veteran-Owned | 
-    <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a> | 
-    <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
+  <footer class="bg-armadilloBlack text-offWhite text-center p-6 mt-8 text-sm max-w-3xl mx-auto rounded-md space-y-4">
+    <div class="flex flex-col sm:flex-row items-center justify-center gap-6 text-base">
+      <div class="text-center sm:text-left">
+        <p class="uppercase text-xs tracking-widest text-oliveGreen mb-1">Phone</p>
+        <a href="tel:19034023814" class="text-offWhite text-lg font-semibold hover:text-oliveGreen transition">
+          (903) 402-3814
+        </a>
+      </div>
+      <span class="hidden sm:inline-flex h-10 border-l border-offWhite/20"></span>
+      <div class="text-center sm:text-left">
+        <p class="uppercase text-xs tracking-widest text-oliveGreen mb-1">Email</p>
+        <a href="mailto:contact@irondillo.com" class="text-offWhite text-lg font-semibold hover:text-oliveGreen transition">
+          contact@irondillo.com
+        </a>
+      </div>
+    </div>
+    <p>&copy; 2025 Iron Dillo. All rights reserved. | Veteran-Owned</p>
+    <p>
+      <a href="/privacy.html" class="hover:underline text-oliveGreen">Privacy</a>
+      <span class="text-offWhite/60">|</span>
+      <a href="/terms.html" class="hover:underline text-oliveGreen">Terms</a>
+    </p>
   </footer>
 
   <script>

--- a/index.html
+++ b/index.html
@@ -174,6 +174,22 @@
       </a>
     </div>
 
+    <div class="flex flex-col md:flex-row items-center justify-center gap-6 mb-8 text-sm sm:text-base">
+      <div class="text-center md:text-left">
+        <p class="uppercase text-xs tracking-widest text-oliveGreen mb-1">Phone</p>
+        <a href="tel:19034023814" class="text-offWhite text-lg font-semibold hover:text-oliveGreen transition">
+          (903) 402-3814
+        </a>
+      </div>
+      <span class="hidden md:inline-flex h-10 border-l border-offWhite/20"></span>
+      <div class="text-center md:text-left">
+        <p class="uppercase text-xs tracking-widest text-oliveGreen mb-1">Email</p>
+        <a href="mailto:contact@irondillo.com" class="text-offWhite text-lg font-semibold hover:text-oliveGreen transition">
+          contact@irondillo.com
+        </a>
+      </div>
+    </div>
+
     <p class="italic mb-4">Trusted by East Texas businesses. Veteran-owned. Mission-driven.</p>
     <div class="space-x-4 mb-4">
       <a href="/privacy.html" class="hover:underline">Privacy</a>


### PR DESCRIPTION
## Summary
- add clearly labeled phone and email contact details to the home page footer
- mirror the same professional contact block within the contact page footer for consistency

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d46acf852c8322802583a34fbcbf3f