### PR TITLE
Update privacy and terms effective dates to 2025

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -48,7 +48,7 @@
   <header class="text-center pt-8 max-w-3xl mx-auto">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="Iron Dillo cybersecurity armadillo logo" class="mx-auto mb-6 w-36 h-auto" />
     <h1 class="text-4xl font-extrabold text-oliveGreen">Privacy Policy</h1>
-    <p class="text-armadilloGray mt-2">Effective Date: June 12, 2026</p>
+    <p class="text-armadilloGray mt-2">Effective Date: June 12, 2025</p>
   </header>
 
   <!-- Navigation -->

--- a/terms.html
+++ b/terms.html
@@ -47,7 +47,7 @@
   <header class="text-center pt-8 max-w-3xl mx-auto">
     <img loading="lazy" src="/assets/irondillo-preview.png" alt="Iron Dillo cybersecurity armadillo logo" class="mx-auto mb-6 w-36 h-auto" />
     <h1 class="text-4xl font-extrabold text-oliveGreen mb-2">Terms and Conditions</h1>
-    <p class="text-armadilloGray">Effective Date: 07/29/2026</p>
+    <p class="text-armadilloGray">Effective Date: 07/29/2025</p>
   </header>
 
   <!-- Navigation -->


### PR DESCRIPTION
### Motivation
- Correct the displayed policy "Effective Date" values to 2025 while leaving existing 2026 copyright and other dates unchanged.

### Description
- Updated the Effective Date text in `privacy.html` from "June 12, 2026" to "June 12, 2025" and in `terms.html` from "07/29/2026" to "07/29/2025".

### Testing
- Verified the edits with `rg -n "Effective Date" privacy.html terms.html && git diff -- privacy.html terms.html`, served the site locally with `python -m http.server 4173`, and captured updated page screenshots via Playwright, all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699216ba4fbc8322bbeafb7c2890027a)