### PR TITLE
Refine homepage hero headline copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
     <main class="relative z-10 max-w-6xl mx-auto px-6 py-10 space-y-8">
       <section class="glass-panel rounded-3xl p-8 md:p-12">
         <p class="pill">Streamlined cybersecurity</p>
-        <h1 class="text-4xl md:text-5xl font-extrabold text-armadilloBlack mt-3 leading-tight">Security leadership support for organizations that need clarity, not noise.</h1>
+        <h1 class="text-4xl md:text-5xl font-extrabold text-armadilloBlack mt-3 leading-tight">Fractional security leadership for teams that need practical direction.</h1>
         <p class="text-lg leading-relaxed text-armadilloGray mt-4 max-w-3xl">Iron Dillo helps small and mid-sized teams cut through complexity with focused assessments, practical roadmaps, and direct implementation support.</p>
         <div class="flex flex-wrap gap-3 mt-6">
           <a class="btn-primary" href="/contact.html">Schedule a consultation</a>


### PR DESCRIPTION
### Motivation
- Replace the generic/AI-like hero phrase with a more human, practical value proposition that matches the site tone while keeping existing styling.

### Description
- Update the homepage headline in `index.html` to: "Fractional security leadership for teams that need practical direction." and preserve the existing typography and utility classes (`text-4xl md:text-5xl font-extrabold ...`).

### Testing
- Verified the change by searching for the old string with `rg -n`, reviewing the `git diff -- index.html`, serving the site with `python3 -m http.server 4173`, and capturing a screenshot via Playwright (Chromium run crashed in this environment but the Firefox-based Playwright run succeeded); all verifications passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69975399796c832284be84b45531116a)