### PR TITLE
Polish site styling with a more grounded tone

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
           <div>
             <p class="pill">Veteran-owned</p>
             <p class="text-offWhite font-semibold text-lg">Iron Dillo Cybersecurity</p>
-            <p class="text-sm text-offWhite/80">Simple plans. Measurable risk reduction.</p>
+            <p class="text-sm text-offWhite/80">Steady security progress for teams with real-world constraints.</p>
           </div>
         </div>
         <nav class="flex flex-wrap items-center gap-3 text-sm">
@@ -52,8 +52,8 @@
     <main class="relative z-10 max-w-6xl mx-auto px-6 py-10 space-y-8">
       <section class="glass-panel rounded-3xl p-8 md:p-12">
         <p class="pill">Practical cybersecurity</p>
-        <h1 class="text-4xl md:text-5xl font-extrabold text-armadilloBlack mt-3 leading-tight">Practical Cybersecurity for Rural Businesses.</h1>
-        <p class="text-lg leading-relaxed text-armadilloGray mt-4 max-w-3xl">Iron Dillo helps rural and small business teams strengthen day-to-day security with clear priorities, practical fixes, and responsive support.</p>
+        <h1 class="text-4xl md:text-5xl font-extrabold text-armadilloBlack mt-3 leading-tight">Cybersecurity that fits how your business actually operates.</h1>
+        <p class="text-lg leading-relaxed text-armadilloGray mt-4 max-w-3xl">Iron Dillo helps rural and small business teams build durable security habits with clear priorities, practical fixes, and support that meets you where you are.</p>
         <div class="flex flex-wrap gap-3 mt-6">
           <a class="btn-primary" href="/contact.html">Schedule a consultation</a>
           <a class="btn-link" href="/services.html">Explore services</a>
@@ -77,8 +77,8 @@
 
       <section class="glass-panel pqc-callout rounded-3xl p-8 md:p-10 space-y-4">
         <p class="pill">Advanced advisory</p>
-        <h2 class="text-3xl font-bold text-armadilloBlack">Fractional security leadership when you need executive coverage.</h2>
-        <p>Need strategic guidance at the leadership level? Fractional engagement is available as a high-tier service for organizations that need governance, planning, and board-ready communication.</p>
+        <h2 class="text-3xl font-bold text-armadilloBlack">Fractional security leadership for organizations in growth mode.</h2>
+        <p>When your team needs structure and direction, fractional engagement adds experienced guidance for governance, planning, and clear leadership communication.</p>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
           <div class="hero-accent rounded-xl p-4">
             <p class="font-semibold text-armadilloBlack text-sm">Roadmap ownership</p>

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,17 @@
 :root {
-  --bg: #f3f5f7;
-  --surface: #ffffff;
-  --surface-soft: #f8fafb;
-  --text: #16202a;
-  --muted: #52606d;
-  --brand: #395d44;
-  --brand-strong: #214131;
-  --border: #d9e2ec;
-  --shadow: 0 12px 30px rgba(22, 32, 42, 0.08);
+  --bg: #edeae3;
+  --surface: #f8f6f1;
+  --surface-soft: #f1eee7;
+  --text: #1f2a24;
+  --muted: #4d5a53;
+  --brand: #3f5c4b;
+  --brand-strong: #2f4739;
+  --border: #d3d0c7;
+  --shadow: 0 10px 24px rgba(21, 29, 24, 0.08);
 }
 
 body {
-  background: linear-gradient(180deg, #f8fafb 0%, #eef3f7 100%);
+  background: linear-gradient(180deg, #f6f3ec 0%, #ebe7de 100%);
   color: var(--muted);
 }
 
@@ -23,9 +23,9 @@ body {
   content: "";
   position: fixed;
   inset: 0;
-  background-image: radial-gradient(circle at 1px 1px, rgba(82, 96, 109, 0.13) 1px, transparent 0);
-  background-size: 28px 28px;
-  opacity: 0.25;
+  background-image: radial-gradient(circle at 1px 1px, rgba(77, 90, 83, 0.1) 1px, transparent 0);
+  background-size: 26px 26px;
+  opacity: 0.18;
   pointer-events: none;
 }
 
@@ -33,12 +33,13 @@ body {
   background: var(--surface);
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
+  backdrop-filter: blur(1px);
 }
 
 .nav-shell {
-  background: #13202b;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow: 0 14px 30px rgba(12, 20, 28, 0.35);
+  background: #27362e;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 12px 24px rgba(26, 36, 30, 0.3);
 }
 
 .nav-shell .pill {
@@ -57,8 +58,8 @@ body {
   align-items: center;
   padding: 0.35rem 0.8rem;
   border-radius: 999px;
-  background: #e8eef2;
-  color: #243b4a;
+  background: #e4e0d6;
+  color: #36453d;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.72rem;
@@ -68,6 +69,12 @@ body {
 .hero-accent {
   background: var(--surface-soft);
   border: 1px solid var(--border);
+}
+
+.glass-panel h1,
+.glass-panel h2,
+.glass-panel h3 {
+  letter-spacing: -0.01em;
 }
 
 .badge-grid,
@@ -108,11 +115,13 @@ body {
   font-weight: 700;
   background: linear-gradient(120deg, var(--brand), var(--brand-strong));
   color: #fff;
-  transition: transform 160ms ease;
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.18);
+  transition: transform 160ms ease, box-shadow 160ms ease;
 }
 
 .btn-primary:hover {
   transform: translateY(-1px);
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.18), 0 8px 16px rgba(47, 71, 57, 0.22);
 }
 
 .btn-link {
@@ -123,8 +132,8 @@ body {
 }
 
 .pqc-callout {
-  border: 1px solid #b8c7d3;
-  background: #f2f7fb;
+  border: 1px solid #c4c2b8;
+  background: #f1eee6;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
### Motivation
- Move the site visual system toward warmer, earthier neutrals and subtler contrast to create a more grounded, less glossy appearance.
- Reduce texture intensity and strong elevation to make panels and navigation feel calmer and more approachable.
- Make the homepage copy feel more practical and steady so messaging matches the toned-down visual design.

### Description
- Updated shared design tokens and surface colors in `styles.css` to warmer neutrals and adjusted the page background gradient and texture density.
- Softened panel and nav elevation, adjusted shadow sizes, added a small `backdrop-filter` blur, and tuned border colors in `styles.css` to reduce glossiness.
- Refined UI details in `styles.css` including pill background/text color, heading letter-spacing, and button inset shadow and hover shadow behavior.
- Updated homepage wording in `index.html` to more practical taglines and clearer messaging around fractional security leadership.

### Testing
- Ran `git diff --check` and it produced no issues (check passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ed4cbe388322a4dcdcade2b6c530)