### PR TITLE
Refocus website messaging on core cybersecurity identity and service pillars

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <title>Iron Dillo Cybersecurity | Independent Rural-First Cybersecurity Practice</title>
-  <meta name="description" content="Independent, veteran-owned cybersecurity practice helping rural businesses, underserved communities, and families with awareness training, readiness checkups, and practical support." />
+  <meta name="description" content="Independent cybersecurity consulting practice focused on cryptographic resilience, future-ready security architecture, practical cyber defense, and underserved organizations." />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta property="og:title" content="Iron Dillo Cybersecurity | Rural-First Practical Cybersecurity Help" />
-  <meta property="og:description" content="Practical cybersecurity awareness, readiness checkups, and hands-on guidance for rural businesses, families, and underserved communities." />
+  <meta property="og:title" content="Iron Dillo Cybersecurity | Practical Cybersecurity and Cryptographic Resilience" />
+  <meta property="og:description" content="Cybersecurity consulting focused on practical defense today and cryptographic resilience for what comes next." />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/styles.css">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -38,7 +38,7 @@
           <div>
             <p class="pill">Veteran-owned</p>
             <p class="text-offWhite font-semibold text-lg">Iron Dillo Cybersecurity</p>
-            <p class="text-sm text-offWhite/80">Independent cybersecurity practice for rural and underserved communities.</p>
+            <p class="text-sm text-offWhite/80">Independent cybersecurity consulting for underserved organizations, including rural communities.</p>
           </div>
         </div>
         <nav class="flex flex-wrap items-center gap-3 text-sm">
@@ -53,9 +53,9 @@
 
     <main class="relative z-10 max-w-6xl mx-auto px-6 py-10 space-y-8">
       <section class="glass-panel rounded-3xl p-8 md:p-12">
-        <p class="pill">Rural-first cybersecurity help</p>
-        <h1 class="text-4xl md:text-5xl font-extrabold text-armadilloBlack mt-3 leading-tight">Practical cybersecurity help for rural businesses, families, and communities.</h1>
-        <p class="text-lg leading-relaxed text-armadilloGray mt-4 max-w-3xl">Iron Dillo helps people build safer everyday habits through awareness training, readiness checkups, and plainspoken hands-on guidance that meets you where you are.</p>
+        <p class="pill">Iron Dillo core identity</p>
+        <h1 class="text-4xl md:text-5xl font-extrabold text-armadilloBlack mt-3 leading-tight">Cybersecurity consulting focused on practical defense and cryptographic resilience.</h1>
+        <p class="text-lg leading-relaxed text-armadilloGray mt-4 max-w-3xl">Iron Dillo supports underserved organizations, including rural teams, with future-ready security architecture, practical cyber defense, and clear plans for cryptographic change.</p>
         <div class="flex flex-wrap gap-3 mt-6">
           <a class="btn-primary" href="/contact.html">Start with a conversation</a>
           <a class="btn-link" href="/services.html">See practical services</a>
@@ -64,40 +64,43 @@
 
       <section class="grid grid-cols-1 md:grid-cols-4 gap-4">
         <article class="glass-panel rounded-2xl p-6">
-          <p class="text-sm font-semibold text-armadilloBlack">Learn the basics</p>
-          <p class="text-sm mt-2">Cyber awareness coaching on phishing, passwords, MFA, and safer browsing habits.</p>
+          <p class="text-sm font-semibold text-armadilloBlack">Cryptographic resilience</p>
+          <p class="text-sm mt-2">Assess where cryptography is used today and what must evolve to stay secure over time.</p>
         </article>
         <article class="glass-panel rounded-2xl p-6">
-          <p class="text-sm font-semibold text-armadilloBlack">Check the essentials</p>
-          <p class="text-sm mt-2">Small-business checkups for websites, email, domains, and exposed internet services.</p>
+          <p class="text-sm font-semibold text-armadilloBlack">Future-ready architecture</p>
+          <p class="text-sm mt-2">Design practical security roadmaps that account for operational realities and long-term change.</p>
         </article>
         <article class="glass-panel rounded-2xl p-6">
-          <p class="text-sm font-semibold text-armadilloBlack">Prepare for disruption</p>
-          <p class="text-sm mt-2">Backup and ransomware readiness support so recovery is possible when something goes wrong.</p>
+          <p class="text-sm font-semibold text-armadilloBlack">Practical cyber defense</p>
+          <p class="text-sm mt-2">Improve resilience with security assessments, readiness planning, and clear implementation guidance.</p>
         </article>
         <article class="glass-panel rounded-2xl p-6">
-          <p class="text-sm font-semibold text-armadilloBlack">Get deeper help when needed</p>
-          <p class="text-sm mt-2">Technical hardening, assessment, and remediation guidance for situations that need extra depth.</p>
+          <p class="text-sm font-semibold text-armadilloBlack">Underserved organizations</p>
+          <p class="text-sm mt-2">Deliver tailored support to rural and resource-constrained organizations without unnecessary overhead.</p>
         </article>
       </section>
 
       <section class="glass-panel pqc-callout rounded-3xl p-8 md:p-10 space-y-4">
-        <p class="pill">Independent practice</p>
-        <h2 class="text-3xl font-bold text-armadilloBlack">Start with practical progress, then scale support as needed.</h2>
-        <p>Most organizations and households do not need enterprise programs on day one. We focus on useful first steps, clear next actions, and honest support that builds confidence over time.</p>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
-          <div class="hero-accent rounded-xl p-4">
-            <p class="font-semibold text-armadilloBlack text-sm">Awareness first</p>
-            <p class="text-sm">Training and education that make security habits stick in everyday work.</p>
+        <p class="pill">Service pillars</p>
+        <h2 class="text-3xl font-bold text-armadilloBlack">Today-revenue services with a long-term differentiator layer.</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="hero-accent rounded-xl p-5">
+            <p class="font-semibold text-armadilloBlack text-sm">Today-revenue services</p>
+            <ul class="text-sm list-disc pl-5 mt-2 space-y-1">
+              <li>Security assessments</li><li>Vulnerability management</li><li>Security awareness</li><li>Policy and documentation</li><li>Fractional security leadership</li><li>Incident readiness</li>
+            </ul>
           </div>
-          <div class="hero-accent rounded-xl p-4">
-            <p class="font-semibold text-armadilloBlack text-sm">Readiness focused</p>
-            <p class="text-sm">Checkups and practical plans that reduce risk without adding heavy overhead.</p>
+          <div class="hero-accent rounded-xl p-5">
+            <p class="font-semibold text-armadilloBlack text-sm">Differentiator layer</p>
+            <ul class="text-sm list-disc pl-5 mt-2 space-y-1">
+              <li>PQC readiness assessments</li><li>Crypto inventory mapping</li><li>Cryptographic agility consulting</li><li>Long-term data risk analysis</li><li>AI/QML security research advisory</li><li>Quantum-risk education</li>
+            </ul>
           </div>
-          <div class="hero-accent rounded-xl p-4">
-            <p class="font-semibold text-armadilloBlack text-sm">Technically capable</p>
-            <p class="text-sm">Custom scripting, automation, and deeper support are available when your needs grow.</p>
-          </div>
+        </div>
+        <div class="hero-accent rounded-xl p-5">
+          <p class="font-semibold text-armadilloBlack text-sm">Research and thought leadership</p>
+          <p class="text-sm mt-2">Whitepapers, proofs-of-concept, experimental tooling, standards interpretation, and speaking/writing to help clients navigate emerging risks with grounded analysis.</p>
         </div>
       </section>
     </main>

--- a/services.html
+++ b/services.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <title>Services | Iron Dillo Cybersecurity</title>
-  <meta name="description" content="Awareness training, security checkups, ransomware readiness, and practical support from an independent cybersecurity practice serving rural and underserved communities." />
+  <meta name="description" content="Cybersecurity consulting services spanning practical defense, cryptographic resilience, and future-ready security architecture for underserved organizations." />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta property="og:title" content="Practical Cybersecurity Services | Iron Dillo Cybersecurity" />
-  <meta property="og:description" content="Start with awareness, checkups, and readiness. Get deeper technical help only when needed." />
+  <meta property="og:title" content="Cybersecurity Consulting Services | Iron Dillo" />
+  <meta property="og:description" content="Service pillars for current security operations and long-term cryptographic resilience." />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/styles.css">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -37,7 +37,7 @@
           <img src="/assets/irondillo-preview.png" alt="Iron Dillo cybersecurity logo" class="w-14 h-14" />
           <div>
             <p class="pill">Services</p>
-            <p class="text-offWhite font-semibold text-lg">Practical support that starts where you are today.</p>
+            <p class="text-offWhite font-semibold text-lg">Services aligned to practical defense and long-term resilience.</p>
           </div>
         </div>
         <nav class="flex flex-wrap items-center gap-3 text-sm">
@@ -52,49 +52,26 @@
     <main class="flex-grow max-w-6xl mx-auto px-6 py-10 space-y-8">
       <section class="glass-panel rounded-3xl p-8 md:p-12 space-y-4">
         <p class="pill">Service model</p>
-        <h1 class="text-4xl font-extrabold text-armadilloBlack">Practical cybersecurity services, from basics to deeper support.</h1>
-        <p class="max-w-3xl">Iron Dillo is an independent cybersecurity practice focused on helping rural and underserved communities take useful next steps without jargon or unnecessary complexity.</p>
+        <h1 class="text-4xl font-extrabold text-armadilloBlack">Service pillars for practical cyber defense and cryptographic resilience.</h1>
+        <p class="max-w-3xl">Iron Dillo is an independent cybersecurity consulting practice focused on cryptographic resilience, future-ready security architecture, practical cyber defense, and underserved organizations.</p>
       </section>
 
       <section class="grid grid-cols-1 md:grid-cols-2 gap-5">
-        <article class="glass-panel rounded-2xl p-7 space-y-2">
-          <h2 class="text-2xl font-semibold text-armadilloBlack">Awareness and Training</h2>
-          <p>Practical coaching for phishing, password safety, MFA, and daily habits that reduce risk for teams and households.</p>
-        </article>
-        <article class="glass-panel rounded-2xl p-7 space-y-2">
-          <h2 class="text-2xl font-semibold text-armadilloBlack">Small-Business Security Checkups</h2>
-          <p>Focused reviews to identify high-impact gaps and prioritize sensible next steps for small organizations with limited technical staff.</p>
-        </article>
-        <article class="glass-panel rounded-2xl p-7 space-y-2">
-          <h2 class="text-2xl font-semibold text-armadilloBlack">Backup and Ransomware Readiness</h2>
-          <p>Backup verification, restore planning, and disruption readiness support so recovery is faster and less chaotic.</p>
-        </article>
-        <article class="glass-panel rounded-2xl p-7 space-y-2">
-          <h2 class="text-2xl font-semibold text-armadilloBlack">Website, Email, and Domain Safety Review</h2>
-          <p>Checks for exposed services, risky configurations, and avoidable weak points across core internet-facing systems.</p>
-        </article>
-        <article class="glass-panel rounded-2xl p-7 space-y-2 md:col-span-2">
-          <h2 class="text-2xl font-semibold text-armadilloBlack">Practical Technical Support</h2>
-          <p>Hands-on help turning findings into action with plain language documentation, implementation guidance, and realistic milestones.</p>
-        </article>
+        <article class="glass-panel rounded-2xl p-7 space-y-2"><h2 class="text-2xl font-semibold text-armadilloBlack">Security Assessments</h2><p>Baseline and targeted assessments that identify exposure, prioritize actions, and support informed decisions.</p></article>
+        <article class="glass-panel rounded-2xl p-7 space-y-2"><h2 class="text-2xl font-semibold text-armadilloBlack">Vulnerability Management</h2><p>Repeatable vulnerability triage and remediation planning tuned to available staff, budget, and operational risk.</p></article>
+        <article class="glass-panel rounded-2xl p-7 space-y-2"><h2 class="text-2xl font-semibold text-armadilloBlack">Security Awareness</h2><p>Role-appropriate awareness programs that improve judgment and reduce common human-factor risks.</p></article>
+        <article class="glass-panel rounded-2xl p-7 space-y-2"><h2 class="text-2xl font-semibold text-armadilloBlack">Policy and Documentation</h2><p>Clear, right-sized policies and procedures that teams can actually maintain and follow.</p></article>
+        <article class="glass-panel rounded-2xl p-7 space-y-2"><h2 class="text-2xl font-semibold text-armadilloBlack">Fractional Security Leadership</h2><p>Part-time strategic security leadership for organizations that need direction without a full-time executive hire.</p></article>
+        <article class="glass-panel rounded-2xl p-7 space-y-2"><h2 class="text-2xl font-semibold text-armadilloBlack">Incident Readiness</h2><p>Preparedness planning, playbooks, and tabletop support to improve response quality before an event occurs.</p></article>
       </section>
 
       <section class="glass-panel pqc-callout rounded-3xl p-8 space-y-4">
-        <h2 class="text-3xl font-bold text-armadilloBlack">When deeper technical help is needed</h2>
-        <p>Some situations require additional depth. When that happens, Iron Dillo can support advanced technical work while keeping recommendations clear and practical.</p>
+        <h2 class="text-3xl font-bold text-armadilloBlack">Differentiator layer and research support</h2>
+        <p>Alongside core services, Iron Dillo helps organizations prepare for cryptographic transition and emerging risk with practical, non-hype guidance.</p>
         <div class="timeline space-y-4">
-          <div class="timeline-step">
-            <h3 class="font-semibold text-armadilloBlack">1. Technical assessments and remediation planning</h3>
-            <p class="text-sm">Targeted assessment support with prioritized remediation guidance.</p>
-          </div>
-          <div class="timeline-step">
-            <h3 class="font-semibold text-armadilloBlack">2. Automation and hardening</h3>
-            <p class="text-sm">Ansible-based hardening and repeatable workflows to improve consistency.</p>
-          </div>
-          <div class="timeline-step">
-            <h3 class="font-semibold text-armadilloBlack">3. Custom scripting and workflow support</h3>
-            <p class="text-sm">Python-based tools and lightweight dashboards for teams ready for deeper technical operations.</p>
-          </div>
+          <div class="timeline-step"><h3 class="font-semibold text-armadilloBlack">1. Cryptographic transition services</h3><p class="text-sm">PQC readiness assessments, crypto inventory mapping, and cryptographic agility consulting.</p></div>
+          <div class="timeline-step"><h3 class="font-semibold text-armadilloBlack">2. Long-horizon risk analysis</h3><p class="text-sm">Long-term data risk analysis plus AI/QML security research advisory for planning under uncertainty.</p></div>
+          <div class="timeline-step"><h3 class="font-semibold text-armadilloBlack">3. Research and thought leadership</h3><p class="text-sm">Whitepapers, proofs-of-concept, experimental tooling, standards interpretation, and speaking/writing engagements.</p></div>
         </div>
       </section>
     </main>


### PR DESCRIPTION
### Motivation
- Shift the site's positioning from a primarily rural-awareness message to a broader, practical cybersecurity consulting identity emphasizing cryptographic resilience, future-ready architecture, practical cyber defense, and support for underserved organizations.
- Align public-facing service descriptions so prospective clients can see both immediate (revenue) services and long-term differentiators like PQC/crypto transition and research/advisory work.

### Description
- Updated metadata and social preview copy in `index.html` and `services.html` to reflect the new core identity and positioning. 
- Rewrote the homepage hero and replaced the feature cards with four core focus areas: `Cryptographic resilience`, `Future-ready architecture`, `Practical cyber defense`, and `Underserved organizations`.
- Added a `Service pillars` section on the homepage enumerating today-revenue services and a differentiator layer plus research/thought-leadership copy. 
- Reworked the `Services` page to list concrete service pillars (security assessments, vulnerability management, security awareness, policy/documentation, fractional security leadership, incident readiness) and added a dedicated differentiator/research section covering PQC readiness, crypto inventory/agility, long-term risk analysis, and AI/QML advisory.

### Testing
- Executed the content update using a focused `python` script which rewrote `index.html` and `services.html` without errors. 
- Listed project files with `rg --files` and inspected updated content fragments with `sed -n` and `nl -ba` to confirm the intended replacements were applied. 
- Reviewed the resulting diffs and file contents to ensure messaging consistency and successful application of the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0de737ab70832299fbb5642e616bbb)