### PR TITLE
Harden draft page and whitepaper indexing protections

### DIFF
--- a/maintenance.html
+++ b/maintenance.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, nofollow, noarchive, nosnippet" />
   <title>Iron Dillo | Cyberstasis Mode</title>
   
   <!-- Google Fonts -->

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,5 @@
 User-agent: *
 Disallow:
+Disallow: /maintenance.html
+Disallow: /assets/QML_Cybersecurity_WhitePaper%20(1).pdf
 Sitemap: https://irondillo.com/sitemap.xml


### PR DESCRIPTION
### Motivation
- Prevent accidental discovery and search-indexing of unpublished draft content (the maintenance/draft page and the whitepaper PDF) by adding explicit noindex controls.

### Description
- Added a `meta name="robots"` tag with `noindex, nofollow, noarchive, nosnippet` to `maintenance.html` to explicitly opt the page out of indexing and snippet generation.
- Added `Disallow: /maintenance.html` and `Disallow: /assets/QML_Cybersecurity_WhitePaper%20(1).pdf` to `robots.txt` to block crawler access to the draft page and the draft whitepaper asset.

### Testing
- Ran `rg -n "robots|maintenance|QML_Cybersecurity" maintenance.html robots.txt` to verify the new directives are present and the command returned matches.
- Inspected file headers with `nl -ba maintenance.html | sed -n '1,20p'` and `nl -ba robots.txt` to confirm the inserted meta tag and `Disallow` lines are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df1174c1c83229b350e48d13b44fe)