### PR TITLE
Remove unnecessary target="_blank" from social links in static HTML pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -82,7 +82,7 @@
     <!-- Social Icons -->
     <div class="inline-flex justify-center space-x-10 mb-8">
       <!-- GitHub -->
-      <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" target="_blank" aria-label="GitHub"
+      <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" aria-label="GitHub"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 .297c-6.63 0-12 5.373-12 12
@@ -103,7 +103,7 @@
       </a>
 
       <!-- Facebook -->
-      <a href="https://www.facebook.com/profile.php?id=61578181152347" target="_blank" aria-label="Facebook"
+      <a href="https://www.facebook.com/profile.php?id=61578181152347" aria-label="Facebook"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M22.675 0h-21.35C.6 0 0 .6 0 1.342v21.316C0
@@ -117,7 +117,7 @@
       </a>
 
       <!-- LinkedIn -->
-      <a href="https://www.linkedin.com/company/iron-dillo/" target="_blank" aria-label="LinkedIn"
+      <a href="https://www.linkedin.com/company/iron-dillo/" aria-label="LinkedIn"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.025-3.037-1.852-3.037

--- a/commitment.html
+++ b/commitment.html
@@ -89,7 +89,7 @@
     <!-- Social Icons -->
     <div class="inline-flex justify-center space-x-10 mb-8">
       <!-- GitHub -->
-      <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" target="_blank" aria-label="GitHub"
+      <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" aria-label="GitHub"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 .297c-6.63 0-12 5.373-12 12
@@ -110,7 +110,7 @@
       </a>
 
       <!-- Facebook -->
-      <a href="https://www.facebook.com/profile.php?id=61578181152347" target="_blank" aria-label="Facebook"
+      <a href="https://www.facebook.com/profile.php?id=61578181152347" aria-label="Facebook"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M22.675 0h-21.35C.6 0 0 .6 0 1.342v21.316C0
@@ -124,7 +124,7 @@
       </a>
 
       <!-- LinkedIn -->
-      <a href="https://www.linkedin.com/company/iron-dillo/" target="_blank" aria-label="LinkedIn"
+      <a href="https://www.linkedin.com/company/iron-dillo/" aria-label="LinkedIn"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.025-3.037-1.852-3.037

--- a/lindale-tyler-cybersecurity.html
+++ b/lindale-tyler-cybersecurity.html
@@ -125,7 +125,7 @@
     <!-- Social Icons -->
     <div class="inline-flex justify-center space-x-10 mb-8">
       <!-- GitHub -->
-      <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" target="_blank" aria-label="GitHub"
+      <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" aria-label="GitHub"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 .297c-6.63 0-12 5.373-12 12
@@ -146,7 +146,7 @@
       </a>
 
       <!-- Facebook -->
-      <a href="https://www.facebook.com/profile.php?id=61578181152347" target="_blank" aria-label="Facebook"
+      <a href="https://www.facebook.com/profile.php?id=61578181152347" aria-label="Facebook"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M22.675 0h-21.35C.6 0 0 .6 0 1.342v21.316C0
@@ -160,7 +160,7 @@
       </a>
 
       <!-- LinkedIn -->
-      <a href="https://www.linkedin.com/company/iron-dillo/" target="_blank" aria-label="LinkedIn"
+      <a href="https://www.linkedin.com/company/iron-dillo/" aria-label="LinkedIn"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.025-3.037-1.852-3.037

--- a/maintenance.html
+++ b/maintenance.html
@@ -79,7 +79,7 @@
     <!-- Social Icons -->
     <div class="inline-flex justify-center space-x-10 mb-8">
       <!-- GitHub -->
-      <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" target="_blank" aria-label="GitHub"
+      <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" aria-label="GitHub"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 .297c-6.63 0-12 5.373-12 12
@@ -100,7 +100,7 @@
       </a>
 
       <!-- Facebook -->
-      <a href="https://www.facebook.com/profile.php?id=61578181152347" target="_blank" aria-label="Facebook"
+      <a href="https://www.facebook.com/profile.php?id=61578181152347" aria-label="Facebook"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M22.675 0h-21.35C.6 0 0 .6 0 1.342v21.316C0
@@ -114,7 +114,7 @@
       </a>
 
       <!-- LinkedIn -->
-      <a href="https://www.linkedin.com/company/iron-dillo/" target="_blank" aria-label="LinkedIn"
+      <a href="https://www.linkedin.com/company/iron-dillo/" aria-label="LinkedIn"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.025-3.037-1.852-3.037

--- a/privacy.html
+++ b/privacy.html
@@ -100,7 +100,7 @@
     <!-- Social Icons -->
     <div class="inline-flex justify-center space-x-10 mb-8">
       <!-- GitHub -->
-      <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" target="_blank" aria-label="GitHub"
+      <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" aria-label="GitHub"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 .297c-6.63 0-12 5.373-12 12
@@ -121,7 +121,7 @@
       </a>
 
       <!-- Facebook -->
-      <a href="https://www.facebook.com/profile.php?id=61578181152347" target="_blank" aria-label="Facebook"
+      <a href="https://www.facebook.com/profile.php?id=61578181152347" aria-label="Facebook"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M22.675 0h-21.35C.6 0 0 .6 0 1.342v21.316C0
@@ -135,7 +135,7 @@
       </a>
 
       <!-- LinkedIn -->
-      <a href="https://www.linkedin.com/company/iron-dillo/" target="_blank" aria-label="LinkedIn"
+      <a href="https://www.linkedin.com/company/iron-dillo/" aria-label="LinkedIn"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.025-3.037-1.852-3.037

--- a/terms.html
+++ b/terms.html
@@ -104,7 +104,7 @@
     <!-- Social Icons -->
     <div class="inline-flex justify-center space-x-10 mb-8">
       <!-- GitHub -->
-      <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" target="_blank" aria-label="GitHub"
+      <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" aria-label="GitHub"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 .297c-6.63 0-12 5.373-12 12
@@ -125,7 +125,7 @@
       </a>
 
       <!-- Facebook -->
-      <a href="https://www.facebook.com/profile.php?id=61578181152347" target="_blank" aria-label="Facebook"
+      <a href="https://www.facebook.com/profile.php?id=61578181152347" aria-label="Facebook"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M22.675 0h-21.35C.6 0 0 .6 0 1.342v21.316C0
@@ -139,7 +139,7 @@
       </a>
 
       <!-- LinkedIn -->
-      <a href="https://www.linkedin.com/company/iron-dillo/" target="_blank" aria-label="LinkedIn"
+      <a href="https://www.linkedin.com/company/iron-dillo/" aria-label="LinkedIn"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.025-3.037-1.852-3.037

--- a/thank-you.html
+++ b/thank-you.html
@@ -88,7 +88,7 @@
     <!-- Social Icons -->
     <div class="inline-flex justify-center space-x-10 mb-8">
       <!-- GitHub -->
-      <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" target="_blank" aria-label="GitHub"
+      <a href="https://github.com/Artilleryjoe/Cybersecurity-Portfolio" aria-label="GitHub"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 .297c-6.63 0-12 5.373-12 12
@@ -109,7 +109,7 @@
       </a>
 
       <!-- Facebook -->
-      <a href="https://www.facebook.com/profile.php?id=61578181152347" target="_blank" aria-label="Facebook"
+      <a href="https://www.facebook.com/profile.php?id=61578181152347" aria-label="Facebook"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M22.675 0h-21.35C.6 0 0 .6 0 1.342v21.316C0
@@ -123,7 +123,7 @@
       </a>
 
       <!-- LinkedIn -->
-      <a href="https://www.linkedin.com/company/iron-dillo/" target="_blank" aria-label="LinkedIn"
+      <a href="https://www.linkedin.com/company/iron-dillo/" aria-label="LinkedIn"
          class="hover:scale-110 transition-transform duration-300 text-oliveGreen hover:text-oliveDark">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
           <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.025-3.037-1.852-3.037


### PR DESCRIPTION
### Motivation
- Ensure predictable navigation and avoid unnecessary new tabs for external social links in static pages. 
- Maintain best-practice security posture by planning to add `rel="noopener noreferrer"` whenever links intentionally open in a new tab. 

### Description
- Removed `target="_blank"` from footer social links (GitHub, Facebook, LinkedIn) in the following files: `privacy.html`, `terms.html`, `404.html`, `thank-you.html`, `maintenance.html`, `commitment.html`, and `lindale-tyler-cybersecurity.html`. 
- Left link targets to open in the same tab since the links did not require opening a new tab, so no `rel="noopener noreferrer"` attributes were added. 
- Updated HTML only in the footer social icon anchor elements and preserved existing classes and SVG icons. 

### Testing
- Ran `rg -n 'target="_blank"' --glob '*.html'` to find usages before the change and confirm matches were present. 
- Ran `rg -n 'target="_blank"|rel="noopener noreferrer"' --glob '*.html'` after the change and confirmed there are no remaining matches. 
- Inspected the affected files with line-numbered checks to verify the social link anchors no longer contain `target="_blank"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df2e71410832281df7b0af88a7da5)