### PR TITLE
Standardize testimonial semantic markup guidance in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,19 @@
           <p class="text-sm mt-2">Whitepapers, proofs-of-concept, experimental tooling, standards interpretation, and speaking/writing to help clients navigate emerging risks with grounded analysis.</p>
         </div>
       </section>
+
+      <!-- Testimonial markup standard (apply on this and future pages):
+           <figure>
+             <blockquote>Quote text…</blockquote>
+             <figcaption>
+               <span>Person name</span><br>
+               <span>Title, Organization</span>
+             </figcaption>
+           </figure>
+           If anonymous, use transparent context such as:
+           "Name withheld by request, Executive Director, nonprofit healthcare"
+           and avoid vague labels like "Happy Client".
+      -->
     </main>
 
     <footer class="relative z-10 bg-armadilloBlack text-offWhite py-10 mt-auto">


### PR DESCRIPTION
### Motivation
- Ensure testimonials use accessible, semantic HTML (`<figure>`, `<blockquote>`, `<figcaption>`) with a clear two-line attribution pattern and transparent handling for anonymous attributions.

### Description
- Added an in-file HTML comment in `index.html` showing the required testimonial structure and recommended attribution patterns (name on line 1, title/organization on line 2), plus guidance for anonymous attributions and a note to avoid vague labels.

### Testing
- Ran `rg -n "testimonial|blockquote|figcaption|figure|Happy Client|client" index.html` to locate testimonial-related content and confirm insertion, which returned successfully.
- Verified the change with `git diff -- index.html` and committed the file with `git commit`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16007d51208322b0a478cce88f3ca4)