### PR TITLE
Add testimonials anchor and homepage nav link

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
         <nav class="flex flex-wrap items-center gap-3 text-sm">
           <a href="/index.html" class="text-offWhite font-semibold px-3 py-2 rounded-xl hover:bg-white/10">Home</a>
           <a href="/services.html" class="text-offWhite font-semibold px-3 py-2 rounded-xl hover:bg-white/10">Services</a>
+          <a href="/#testimonials" class="text-offWhite font-semibold px-3 py-2 rounded-xl hover:bg-white/10">Reviews</a>
           <a href="/about.html" class="text-offWhite font-semibold px-3 py-2 rounded-xl hover:bg-white/10">About</a>
           <a href="/contact.html" class="text-offWhite font-semibold px-3 py-2 rounded-xl hover:bg-white/10">Contact</a>
           <a href="tel:19039331342" class="btn-primary text-sm">Call (903) 933-1342</a>
@@ -65,7 +66,7 @@
         </article>
       </section>
 
-      <section class="glass-panel pqc-callout rounded-3xl p-8 md:p-10 space-y-4">
+      <section id="testimonials" class="glass-panel pqc-callout rounded-3xl p-8 md:p-10 space-y-4">
         <p class="pill">Service pillars</p>
         <h2 class="text-3xl font-bold text-armadilloBlack">Today-revenue services with a long-term differentiator layer.</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">


### PR DESCRIPTION
### Motivation
- Provide a direct anchor to the testimonials section and expose it from the homepage nav while avoiding mobile nav wrapping issues by using a short label.

### Description
- Added `id="testimonials"` to the target section in `index.html` and inserted a nav link to `/#testimonials` labeled `Reviews` using the same nav styling as existing items.

### Testing
- Verified the change and anchor/link pairing with `git diff -- index.html` and checked repository status with `git status --short`, then recorded the change with a commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16007e0664832299d61bbf12672d5b)