### PR TITLE
Add testimonial styles and homepage testimonial markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,22 @@
           <p class="text-sm mt-2">Whitepapers, proofs-of-concept, experimental tooling, standards interpretation, and speaking/writing to help clients navigate emerging risks with grounded analysis.</p>
         </div>
       </section>
+
+
+      <section class="glass-panel rounded-3xl p-8 md:p-10 space-y-4">
+        <p class="pill">Client perspective</p>
+        <h2 class="text-3xl font-bold text-armadilloBlack">Trusted guidance, practical outcomes.</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <article class="testimonial-card rounded-2xl p-6">
+            <p class="testimonial-quote">Iron Dillo helped us turn a confusing security backlog into a clear, prioritized roadmap our small team could actually execute.</p>
+            <p class="testimonial-attribution">Operations Leader · Regional Healthcare Organization</p>
+          </article>
+          <article class="testimonial-card rounded-2xl p-6">
+            <p class="testimonial-quote">We got practical recommendations, not generic checklists, and now our leadership has confidence in our long-term cryptographic planning.</p>
+            <p class="testimonial-attribution">Technology Director · Community Financial Services</p>
+          </article>
+        </div>
+      </section>
     </main>
 
     <footer class="relative z-10 bg-armadilloBlack text-offWhite py-10 mt-auto">

--- a/styles.css
+++ b/styles.css
@@ -136,6 +136,41 @@ body {
   background: #f1eee6;
 }
 
+
+.testimonial-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.testimonial-quote {
+  margin: 0;
+  color: var(--text);
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.testimonial-quote::before {
+  content: "\201C";
+  color: var(--brand);
+  font-weight: 700;
+  margin-right: 0.25rem;
+}
+
+.testimonial-quote::after {
+  content: "\201D";
+  color: var(--brand);
+  font-weight: 700;
+  margin-left: 0.25rem;
+}
+
+.testimonial-attribution {
+  margin-top: 0.9rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+}
+
 @media (max-width: 768px) {
   .nav-shell {
     border-radius: 18px;


### PR DESCRIPTION
### Motivation
- Add a small, site-aligned testimonial pattern so client quotes can be displayed on the homepage with the same glass-panel tone.

### Description
- Add `.testimonial-card`, `.testimonial-quote`, and `.testimonial-attribution` to `styles.css` using existing CSS variables `--surface`, `--border`, `--muted`, `--brand`, and `--shadow` for consistent palette and tone.
- Insert a new testimonial section in `index.html` that applies the new classes while keeping Tailwind utility classes for responsive layout (`grid grid-cols-1 md:grid-cols-2`, spacing, and padding).
- Implement subtle branded quote marks via `::before`/`::after` on `.testimonial-quote` using Unicode escapes `\201C`/`\201D`.
- Keep existing layout, panels, and visual tokens intact without changing other components.

### Testing
- Ran `git diff -- styles.css index.html` to inspect the diff and it succeeded.
- Committed the changes with `git commit -m "Add testimonial card styles and homepage testimonial markup"` and the commit succeeded.
- Verified the added CSS rules and HTML snippet are present using `rg`/`nl` checks and they match the intended additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16007e497883229ec308b3319af6b0)