### PR TITLE
Restore homepage asset imagery (Bluebonnet & Dilloman)

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,24 @@
         </div>
       </section>
 
+
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <article class="glass-panel rounded-3xl overflow-hidden">
+          <img src="/assets/Bluebonnet.png" alt="Bluebonnet field in Texas" class="w-full h-64 object-cover" />
+          <div class="p-6">
+            <p class="pill">Rooted in Texas</p>
+            <p class="mt-3 text-sm">We protect the communities and businesses our region depends on with practical, local-first cybersecurity guidance.</p>
+          </div>
+        </article>
+        <article class="glass-panel rounded-3xl overflow-hidden">
+          <img src="/assets/Dilloman.jpg" alt="Iron Dillo founder portrait" class="w-full h-64 object-cover" />
+          <div class="p-6">
+            <p class="pill">Personal support</p>
+            <p class="mt-3 text-sm">Direct collaboration and clear communication from assessment through implementation.</p>
+          </div>
+        </article>
+      </section>
+
       <section class="grid grid-cols-1 md:grid-cols-4 gap-4">
         <article class="glass-panel rounded-2xl p-6">
           <p class="text-sm font-semibold text-armadilloBlack">Cryptographic resilience</p>


### PR DESCRIPTION
### Motivation
- The homepage no longer displayed included asset photos, removing the visual bluebonnet field and founder portrait from the main landing experience. 
- These images are intended to reinforce the Texas-rooted messaging and personal-support positioning of the site. 
- Restore the visual section so the shipped assets in `assets/` are surfaced on the homepage.

### Description
- Inserted a new two-card visual section into `index.html` that displays two image cards side-by-side on medium+ screens. 
- The section includes `img` tags referencing `/assets/Bluebonnet.png` and `/assets/Dilloman.jpg` with accompanying pill labels and short descriptive copy. 
- The new section is placed immediately before the four-column feature grid so visuals appear near the hero content and follow existing utility classes.

### Testing
- Confirmed that `index.html` contains the new section and two `img` tags referencing `/assets/Bluebonnet.png` and `/assets/Dilloman.jpg` via a local file search. 
- Verified the referenced image files exist in the `assets/` directory. 
- No automated test suite was run because this is a static HTML/CSS content update; there were no build steps required and the change is validated by the local content checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1605d860448322907db312e1229365)