### PR TITLE
Fix contact page CSP to allow Formspree challenge flow

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="/assets/tailwind.css">
 
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self'; frame-ancestors 'none';">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
   <meta http-equiv="Permissions-Policy" content="accelerometer=(), camera=(), geolocation=(), gyroscope=(), microphone=(), payment=(), usb=()">


### PR DESCRIPTION
### Motivation
- The inline `Content-Security-Policy` in `contact.html` was too restrictive and could block Formspree anti-spam challenge scripts and frames served from Google domains.
- The contact page CSP should align with the project’s canonical header policy so challenge flows function while preserving clickjacking protections.

### Description
- Updated the `Content-Security-Policy` meta tag in `contact.html` to allow `https://cdn.tailwindcss.com`, `https://unpkg.com`, `https://www.google.com`, and `https://www.gstatic.com` in `script-src`.
- Added `https://cdn.tailwindcss.com` to `style-src`, added `frame-src https://www.google.com`, and included `frame-ancestors 'none'` to align with the intended site-wide header policy.
- Change is confined to the single file `contact.html` and does not alter site content or assets.

### Testing
- Ran `npm run build:tailwind` and the Tailwind build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1607956af88322bb86e84e366eb6df)