### PR TITLE
Remove duplicate Content-Security-Policy meta tags from policy and landing pages

### DIFF
--- a/lindale-tyler-cybersecurity.html
+++ b/lindale-tyler-cybersecurity.html
@@ -22,7 +22,6 @@
   <meta name="twitter:card" content="summary_large_image" />
 
   <!-- 🛡 Security Headers -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">

--- a/privacy.html
+++ b/privacy.html
@@ -13,7 +13,6 @@
   <link rel="stylesheet" href="/assets/tailwind.css">
 
   <!-- Security Headers -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">

--- a/terms.html
+++ b/terms.html
@@ -13,7 +13,6 @@
   <link rel="stylesheet" href="/assets/tailwind.css">
 
   <!-- Security Headers -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; frame-src https://www.google.com; form-action 'self' https://formspree.io; object-src 'none'; base-uri 'self';">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">


### PR DESCRIPTION
### Motivation
- Eliminate conflicting/duplicate `Content-Security-Policy` meta tags so each page has a single authoritative CSP to ensure consistent browser enforcement and the intended `frame-ancestors 'none'` restriction.

### Description
- Removed redundant `Content-Security-Policy` meta tag occurrences from `privacy.html`, `terms.html`, and `lindale-tyler-cybersecurity.html`, preserving the canonical CSP that includes `https://cdn.tailwindcss.com` and `frame-ancestors 'none'`.
- No other markup or content changes were made to the edited pages.

### Testing
- Ran `rg -n "Content-Security-Policy"` on the edited files to confirm each now contains exactly one CSP meta tag, and the check succeeded.
- Executed the repository-wide Python check that verifies every HTML file contains exactly one CSP meta tag using `python - <<'PY' ...`, and it reported success.
- Executed the local href/action validation script `python - <<'PY' ...` to ensure no broken local links or form actions were introduced, and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1609b3b1a8832284a06fc6bc2b7504)