### PR TITLE
Add full site audit report and fix missing meta descriptions

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,0 +1,42 @@
+# Full Site & Code Audit
+
+Date: 2026-05-26 (UTC)
+
+## Scope
+- Static HTML pages
+- Tailwind build configuration
+- Routing/content integrity
+- Baseline SEO/accessibility/security checks
+
+## Automated checks run
+1. Internal link validation across all local HTML pages
+2. Image `alt` presence scan
+3. Presence of `<h1>` per page
+4. Presence of meta descriptions per page
+5. `target="_blank"` links missing `rel` protections
+
+## Findings
+
+### ✅ Structure and navigation
+- All discovered internal links resolved to existing files.
+- No broken local page references were detected in the HTML files scanned.
+
+### ✅ Accessibility baseline
+- All scanned `<img>` elements included non-empty `alt` text.
+- All scanned HTML pages included at least one `<h1>` heading.
+
+### ✅ Security baseline
+- `_headers` includes CSP, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and X-Frame-Options.
+- No anchor tags using `target="_blank"` were found without `rel="noopener"`/`noreferrer` in the current scan.
+
+### ⚠️ SEO gaps (fixed)
+- `maintenance.html` was missing a meta description.
+- `thank-you.html` was missing a meta description.
+
+Both are now updated in this commit.
+
+## Recommendations (next phase)
+- Add a repeatable lint/audit script (HTML lint + link checker) to CI so regressions are caught on each push.
+- Consider consolidating repeated head/footer partials with a build step to reduce duplication risk.
+- Add performance budgets and run Lighthouse in CI for core pages (`index.html`, `services.html`, `contact.html`).
+- Consider adding `connect-src` explicitly in CSP if future third-party APIs are introduced.

--- a/maintenance.html
+++ b/maintenance.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Iron Dillo Cybersecurity is temporarily in maintenance mode while we deploy site upgrades and security improvements." />
   <meta name="robots" content="noindex, nofollow, noarchive, nosnippet" />
   <title>Iron Dillo | Cyberstasis Mode</title>
   

--- a/thank-you.html
+++ b/thank-you.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <title>Thank You | Iron Dillo Cybersecurity</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Thank you for contacting Iron Dillo Cybersecurity. Your message was sent successfully and we will respond shortly." />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/tailwind.css">
   <!-- 🛡 Security Headers -->


### PR DESCRIPTION
### Motivation
- Provide a one-stop audit of the static site to record scope, automated checks, findings, and next-step recommendations.
- Close small SEO gaps discovered during the audit by ensuring all pages include a `meta name="description"` tag.

### Description
- Add `AUDIT_REPORT.md` containing the audit scope, checks performed, findings, and recommendations.
- Add `meta name="description"` to `maintenance.html` with a brief maintenance-mode description.
- Add `meta name="description"` to `thank-you.html` with a short acknowledgement message.
- No other site content or navigation links were changed.

### Testing
- Ran the Tailwind build with `npm run build`, which completed successfully but emitted non-blocking warnings about `http-proxy` config and outdated `caniuse-lite` data.
- Re-ran the automated HTML audit (custom Python checks) which verified there are zero missing internal links across local pages.
- The audit confirmed no images with empty `alt` text, every page has an `<h1>`, and no pages are missing meta descriptions after the updates.
- All automated checks listed in `AUDIT_REPORT.md` passed on the updated files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a161799cf148322bf51a2d07e084299)