### PR TITLE
Remove Dilloman portrait from home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,19 +48,12 @@
       </section>
 
 
-      <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <section class="grid grid-cols-1 gap-4">
         <article class="glass-panel rounded-3xl overflow-hidden">
           <img src="/assets/Bluebonnet.png" alt="Bluebonnet field in Texas" class="w-full h-64 object-cover" />
           <div class="p-6">
             <p class="pill">Rooted in Texas</p>
             <p class="mt-3 text-sm">We protect the communities and businesses our region depends on with practical, local-first cybersecurity guidance.</p>
-          </div>
-        </article>
-        <article class="glass-panel rounded-3xl overflow-hidden">
-          <img src="/assets/Dilloman.jpg" alt="Iron Dillo founder portrait" class="w-full h-64 object-cover" />
-          <div class="p-6">
-            <p class="pill">Personal support</p>
-            <p class="mt-3 text-sm">Direct collaboration and clear communication from assessment through implementation.</p>
           </div>
         </article>
       </section>


### PR DESCRIPTION
### Motivation
- Remove the founder portrait from the home page so `Dilloman.jpg` is only presented on the About page and the homepage layout is simplified.

### Description
- Deleted the portrait article from `index.html` and updated the section class from `md:grid-cols-2` to a single-column grid (`grid-cols-1`) to match the remaining content.

### Testing
- No automated tests were run because this is a static HTML content change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1626c0be8c83229a23f8a2581d6df9)