### PR TITLE
Disable interactivity for reviews/testimonials pending rollout

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
         <nav class="flex flex-wrap items-center gap-3 text-sm">
           <a href="/index.html" class="text-offWhite font-semibold px-3 py-2 rounded-xl hover:bg-white/10">Home</a>
           <a href="/services.html" class="text-offWhite font-semibold px-3 py-2 rounded-xl hover:bg-white/10">Services</a>
-          <a href="/#testimonials" class="text-offWhite font-semibold px-3 py-2 rounded-xl hover:bg-white/10">Reviews</a>
+          <span class="text-offWhite/60 font-semibold px-3 py-2 rounded-xl cursor-not-allowed" aria-disabled="true" title="Reviews coming soon">Reviews</span>
           <a href="/about.html" class="text-offWhite font-semibold px-3 py-2 rounded-xl hover:bg-white/10">About</a>
           <a href="/contact.html" class="text-offWhite font-semibold px-3 py-2 rounded-xl hover:bg-white/10">Contact</a>
           <a href="tel:19039331342" class="btn-primary text-sm">Call (903) 933-1342</a>
@@ -108,8 +108,8 @@
       </section>
 
 
-      <section class="glass-panel rounded-3xl p-8 md:p-10 space-y-4">
-        <p class="pill">Client perspective</p>
+      <section class="glass-panel rounded-3xl p-8 md:p-10 space-y-4 opacity-60 pointer-events-none select-none" aria-disabled="true" inert>
+        <p class="pill">Client perspective (coming soon)</p>
         <h2 class="text-3xl font-bold text-armadilloBlack">Trusted guidance, practical outcomes.</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <article class="testimonial-card rounded-2xl p-6">


### PR DESCRIPTION
### Motivation
- Prevent users from interacting with the reviews/testimonials area until the feature is ready while keeping the content visible in the layout.
- Provide a clear visual signal that the testimonials area is not yet available by reducing emphasis and marking it as coming soon.
- Avoid removing markup so the section can be re-enabled with minimal changes when rollout begins.

### Description
- Replaced the header "Reviews" anchor with a non-interactive `<span>` styled with `text-offWhite/60`, `cursor-not-allowed`, and `aria-disabled="true"` to prevent navigation to the section.
- Made the testimonials section non-interactive by adding `opacity-60`, `pointer-events-none`, `select-none`, `aria-disabled="true"`, and the `inert` attribute to the section element and updated the pill text to `Client perspective (coming soon)`. 
- Kept all testimonial markup in place so content and layout remain unchanged visually aside from the disabled styling.

### Testing
- Ran the in-place update script to modify `index.html` and verified the replacements completed without errors.
- Inspected the resulting HTML snippet with `nl -ba index.html | sed -n '24,135p'` to confirm the header link was replaced and the testimonials section has the new attributes and classes.
- Performed repository diff and status checks to ensure the change is present and recorded, and those checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16270d84e483229e8d95a27b34dd87)