### PR TITLE
Remove Reviews navigation item from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
         <nav class="flex flex-wrap items-center gap-3 text-sm">
           <a href="/index.html" class="text-offWhite font-semibold px-3 py-2 rounded-xl hover:bg-white/10">Home</a>
           <a href="/services.html" class="text-offWhite font-semibold px-3 py-2 rounded-xl hover:bg-white/10">Services</a>
-          <span class="text-offWhite/60 font-semibold px-3 py-2 rounded-xl cursor-not-allowed" aria-disabled="true" title="Reviews coming soon">Reviews</span>
           <a href="/about.html" class="text-offWhite font-semibold px-3 py-2 rounded-xl hover:bg-white/10">About</a>
           <a href="/contact.html" class="text-offWhite font-semibold px-3 py-2 rounded-xl hover:bg-white/10">Contact</a>
           <a href="tel:19039331342" class="btn-primary text-sm">Call (903) 933-1342</a>


### PR DESCRIPTION
### Motivation
- The homepage navigation included a disabled "Reviews" item that should not be visible while reviews are not available, so it was removed to avoid showing a non-functional UI element.

### Description
- Deleted the disabled `Reviews` nav element from `index.html` header to keep the top navigation focused on active sections.

### Testing
- Verified with `rg -q "Reviews coming soon|>Reviews<" index.html` which returned `not found`, confirming the item was removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16294a750883228ce8a7e341461855)