### PR TITLE
Remove non-genuine placeholder testimonials from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,21 +99,6 @@
         </div>
       </section>
 
-
-      <section class="glass-panel rounded-3xl p-8 md:p-10 space-y-4 opacity-60 pointer-events-none select-none" aria-disabled="true" inert>
-        <p class="pill">Client perspective (coming soon)</p>
-        <h2 class="text-3xl font-bold text-armadilloBlack">Trusted guidance, practical outcomes.</h2>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <article class="testimonial-card rounded-2xl p-6">
-            <p class="testimonial-quote">Iron Dillo helped us turn a confusing security backlog into a clear, prioritized roadmap our small team could actually execute.</p>
-            <p class="testimonial-attribution">Operations Leader · Regional Healthcare Organization</p>
-          </article>
-          <article class="testimonial-card rounded-2xl p-6">
-            <p class="testimonial-quote">We got practical recommendations, not generic checklists, and now our leadership has confidence in our long-term cryptographic planning.</p>
-            <p class="testimonial-attribution">Technology Director · Community Financial Services</p>
-          </article>
-        </div>
-      </section>
     </main>
 
     <footer class="relative z-10 bg-armadilloBlack text-offWhite py-10 mt-auto">


### PR DESCRIPTION
### Motivation
- Remove placeholder testimonial content that could be misleading or unethical to display when no real customer reviews exist.

### Description
- Deleted the disabled "Client perspective (coming soon)" testimonial block from `index.html`, removing fabricated quote and attribution cards while leaving surrounding sections intact.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a162a0d489083228aafeb4f03104031)