### PR TITLE
Fix services bullet list formatting

### DIFF
--- a/services.html
+++ b/services.html
@@ -53,11 +53,11 @@
       <section class="glass-panel pqc-callout rounded-3xl p-8 space-y-4">
         <h2 class="text-3xl font-bold text-armadilloBlack">Differentiator layer and research support</h2>
         <p>Alongside core services, Iron Dillo helps organizations prepare for cryptographic transition and emerging risk with practical, non-hype guidance.</p>
-        <div class="timeline space-y-4">
-          <div class="timeline-step"><h3 class="font-semibold text-armadilloBlack">1. Cryptographic transition services</h3><p class="text-sm">PQC readiness assessments, crypto inventory mapping, and cryptographic agility consulting.</p></div>
-          <div class="timeline-step"><h3 class="font-semibold text-armadilloBlack">2. Long-horizon risk analysis</h3><p class="text-sm">Long-term data risk analysis plus AI/QML security research advisory for planning under uncertainty.</p></div>
-          <div class="timeline-step"><h3 class="font-semibold text-armadilloBlack">3. Research and thought leadership</h3><p class="text-sm">Whitepapers, proofs-of-concept, experimental tooling, standards interpretation, and speaking/writing engagements.</p></div>
-        </div>
+        <ul class="service-list space-y-4">
+          <li><h3 class="font-semibold text-armadilloBlack">Cryptographic transition services</h3><p class="text-sm">PQC readiness assessments, crypto inventory mapping, and cryptographic agility consulting.</p></li>
+          <li><h3 class="font-semibold text-armadilloBlack">Long-horizon risk analysis</h3><p class="text-sm">Long-term data risk analysis plus AI/QML security research advisory for planning under uncertainty.</p></li>
+          <li><h3 class="font-semibold text-armadilloBlack">Research and thought leadership</h3><p class="text-sm">Whitepapers, proofs-of-concept, experimental tooling, standards interpretation, and speaking/writing engagements.</p></li>
+        </ul>
       </section>
     </main>
 

--- a/styles.css
+++ b/styles.css
@@ -205,25 +205,18 @@ main .glass-panel:not(.site-hero):not(.home-hero):hover {
   gap: 1rem;
 }
 
-.timeline {
-  border-left: 2px solid #9fc4e2;
-  padding-left: 1rem;
+.service-list {
+  list-style: disc;
+  padding-left: 1.5rem;
 }
 
-.timeline-step {
-  position: relative;
-  padding-left: 0.75rem;
+.service-list li {
+  padding-left: 0.25rem;
 }
 
-.timeline-step::before {
-  content: "";
-  position: absolute;
-  left: -1.47rem;
-  top: 0.35rem;
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  background: var(--brand);
+.service-list li::marker {
+  color: var(--brand);
+  font-size: 1.15em;
 }
 
 .btn-primary {


### PR DESCRIPTION
### Motivation
- Improve the visual and semantic formatting of the service bullet points on the Services page by replacing the decorative timeline markup with a standard list that works consistently across browsers and assistive technologies.

### Description
- Replace the timeline block in `services.html` with a semantic unordered list using the `service-list` class and remove manual numeric prefixes from items.
- Remove the `.timeline` / `.timeline-step` decorations and add `.service-list`, `.service-list li`, and `.service-list li::marker` rules to `styles.css` to restore spacing and apply the brand color to list markers.

### Testing
- Ran `npm run build` which completed successfully and rebuilt `assets/tailwind.css`.
- Ran `git diff --check` which reported no whitespace or check issues.
- Parsed `services.html` using Python's `html.parser` successfully to validate well-formed HTML.
- Attempted `npx -y playwright@1.55.0 install chromium` to capture a screenshot, but the install failed with an HTTP 403 from the registry so no browser-based screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e3f7edfa48322a3d79a81ecb710a5)