### PR TITLE
Refine the good-enough cybersecurity article copy

### DIFF
--- a/good-enough-cybersecurity-small-organizations.html
+++ b/good-enough-cybersecurity-small-organizations.html
@@ -43,15 +43,15 @@
           <a href="/blog.html" class="btn-link text-sm">← Back to the blog</a>
           <p class="pill mt-6">Field Notes No. 2 · Practical baseline</p>
           <h1 class="text-3xl sm:text-4xl md:text-5xl font-extrabold text-armadilloBlack mt-5 leading-tight">What Does ‘Good Enough’ Cybersecurity Look Like for a Small Organization?</h1>
-          <p class="text-lg sm:text-xl leading-relaxed mt-6">A Practical Cybersecurity Baseline for Small Businesses in 2026: built around seven questions leaders can answer without pretending risk can be eliminated.</p>
+          <p class="text-lg sm:text-xl leading-relaxed mt-6">A practical cybersecurity baseline for small businesses in 2026, built around seven questions leaders can answer without pretending risk can be eliminated.</p>
           <p class="text-sm mt-6"><time datetime="2026-07-27">July 27, 2026</time> · 11 min read · Iron Dillo Cybersecurity</p>
         </header>
 
-        <p class="article-lead">A Practical Cybersecurity Baseline for Small Businesses in 2026 starts with an honest premise: a small organization does not need perfect security. It needs controls that address its most consequential risks, people who know what to do, and a recovery path that has been practiced.</p>
+        <p class="article-lead">A credible cybersecurity baseline starts with an honest premise: a small organization does not need perfect security. It needs controls that address its most consequential risks, people who know what to do, and a recovery path that has been practiced.</p>
 
         <h2>Perfection is not the standard</h2>
         <p>No organization can prevent every malicious email, software flaw, vendor failure, stolen device, or human mistake. Trying to do so can consume limited money and attention while leaving basic protections unfinished. The better objective is defensible risk reduction: understand what the organization depends on, make common attacks harder, limit the damage when something gets through, and restore essential work.</p>
-        <p>This follows the practical approach described in <a href="/built-for-the-real-world.html">Built for the Real World</a>. Small businesses, nonprofits, rural offices, local governments, and family operations share enterprise-sized dependencies without enterprise staffing. Their baseline must fit the people, technology, connectivity, budget, and consequences they actually have.</p>
+        <p>This follows the practical approach described in <a href="/built-for-the-real-world.html">Built for the Real World</a>. Small businesses, nonprofits, rural offices, local governments, and family operations share enterprise-sized dependencies without enterprise staffing. Their baseline must fit the people, technology, connectivity, budget, and consequences they actually face.</p>
         <p>“Good enough” is therefore not “the least we can get away with.” Corner-cutting ignores a known danger, leaves ownership unclear, or buys a tool without maintaining it. Defensible good-enough security makes deliberate choices, records important exceptions, assigns responsibility, and revisits decisions as the business changes. It can explain why a protection is present, how anyone knows it works, and what happens when it fails.</p>
 
         <aside class="article-callout">
@@ -60,8 +60,8 @@
         </aside>
 
         <h2>Use frameworks as maps, not scorecards</h2>
-        <p>Authoritative frameworks help leaders ask better questions. The <a href="https://www.nist.gov/cyberframework" rel="noopener noreferrer">NIST Cybersecurity Framework 2.0</a> organizes outcomes around Govern, Identify, Protect, Detect, Respond, and Recover. Its <a href="https://www.nist.gov/publications/navigating-nist-cybersecurity-framework-csf-20-small-business-quick-start-guide" rel="noopener noreferrer">Small Business Quick-Start Guide</a> translates that structure for organizations with modest or no cybersecurity plans. <a href="https://www.cisa.gov/audiences/small-and-medium-businesses" rel="noopener noreferrer">CISA’s small-business guidance</a> provides accessible actions and resources, while <a href="https://www.cisecurity.org/controls/implementation-groups/ig1" rel="noopener noreferrer">CIS Critical Security Controls Implementation Group 1</a> describes essential cyber hygiene intended to be achievable with limited expertise and resources.</p>
-        <p>None of these resources requires a small organization to copy a large company. Use them to check coverage and priorities, not to generate paperwork for its own sake. A concise plan that people follow is more valuable than a complete-looking binder nobody can use.</p>
+        <p>Authoritative frameworks help leaders ask better questions. The <a href="https://www.nist.gov/cyberframework" rel="noopener noreferrer">NIST Cybersecurity Framework 2.0</a> organizes outcomes around Govern, Identify, Protect, Detect, Respond, and Recover. Its <a href="https://www.nist.gov/publications/navigating-nist-cybersecurity-framework-csf-20-small-business-quick-start-guide" rel="noopener noreferrer">Small Business Quick-Start Guide</a> adapts that structure for organizations with modest or no cybersecurity plans. <a href="https://www.cisa.gov/audiences/small-and-medium-businesses" rel="noopener noreferrer">CISA</a> provides practical resources for small and medium businesses, while <a href="https://www.cisecurity.org/controls/implementation-groups/ig1" rel="noopener noreferrer">CIS Critical Security Controls Implementation Group 1</a> offers a prioritized foundation of essential cyber hygiene.</p>
+        <p>Use them to check coverage and priorities, not to generate paperwork for its own sake. A concise plan that people follow is more valuable than a complete-looking binder nobody can use.</p>
 
         <h2>The seven-question test</h2>
         <p>The most useful baseline is one a leader can test in plain language. Gather the owner or executive, the person responsible for technology, and the people who run essential operations. Ask these seven questions. Evidence matters more than a confident yes.</p>
@@ -73,7 +73,7 @@
         <p>Important email, banking, payroll, cloud administration, remote access, and backup accounts should use unique credentials and multifactor authentication, preferably passkeys or security keys where practical. Remove former workers promptly, avoid shared administrator accounts, and secure recovery email addresses and phone numbers. Review who has powerful or vendor access and whether they still need it.</p>
 
         <h3>3. Are devices, software, and internet-facing systems maintained?</h3>
-        <p>Turn on automatic updates when operations allow, and promptly address supported browsers, operating systems, routers, remote-access products, website software, and cloud applications. Know where unsupported equipment remains. If replacement must wait, reduce its access, isolate it where feasible, and record both the risk and the plan.</p>
+        <p>Turn on automatic updates when operations allow. Keep supported browsers, operating systems, routers, remote-access products, website software, and cloud applications current, prioritizing anything exposed to the internet. Know where unsupported equipment remains. If replacement must wait, reduce its access, isolate it where feasible, and record both the risk and the plan.</p>
 
         <h3>4. Can we recognize and contain trouble?</h3>
         <p>People should know how to report a suspicious message, unexpected login approval, changed payment request, lost device, or unusual system behavior without fear of blame. Ensure someone receives useful alerts from major accounts, security tools, and service providers. Define who can disconnect a device, disable an account, or call the technology provider when minutes matter.</p>
@@ -105,6 +105,7 @@
         </aside>
 
         <h2>Build a sustainable operating rhythm</h2>
+        <p>Using Iron Dillo’s GRIT model, turn the baseline into a recurring operating rhythm rather than a one-time project.</p>
         <p><strong>Monthly:</strong> practice <strong>Tenacity</strong>. Confirm updates and backups are completing, review important alerts, remove access that is no longer needed, and discuss suspicious requests or near misses. Keep this review short and assign unfinished work.</p>
         <p><strong>Quarterly:</strong> strengthen <strong>Resilience</strong> and <strong>Instinct</strong>. Restore something meaningful, verify emergency contacts, review critical vendors and privileged access, and walk through one plausible event such as compromised email, unavailable internet, or ransomware. Ask what people noticed, who decided, and what slowed recovery.</p>
         <p><strong>Annually:</strong> choose <strong>Growth</strong>. Revisit the critical-service list, business impact, insurance requirements, major technology changes, and the seven questions. Update the incident guide, set the next few priorities, and fund improvements the organization can operate. Growth, Resilience, Instinct, and Tenacity work together: improve deliberately, recover reliably, recognize trouble, and keep doing the basics.</p>


### PR DESCRIPTION
### Motivation
- Improve clarity and tone in the article lead and subtitle to avoid an SEO-sounding opening and a sentence-fragment subtitle. 
- Make small wording fixes that better reflect practical guidance for small organizations (e.g., change from what organizations “have” to what they “face”).
- Tighten framework guidance and make the update/maintenance guidance clearer and more actionable. 
- Introduce the GRIT model before using its component names so readers see the model context before encountering capitalized terms.

### Description
- Edited `good-enough-cybersecurity-small-organizations.html` to replace the subtitle with: `A practical cybersecurity baseline for small businesses in 2026, built around seven questions leaders can answer without pretending risk can be eliminated.`
- Replaced the SEO-heavy opening sentence with: `A credible cybersecurity baseline starts with an honest premise: a small organization does not need perfect security...` to improve tone and flow.
- Reworded the baseline sentence to use `face` instead of `have` so it reads: `Their baseline must fit the people, technology, connectivity, budget, and consequences they actually face.`
- Tightened the frameworks paragraph (use `adapts` instead of `translates`, clarified CISA and CIS wording) and clarified Question 3 by splitting the update guidance into two sentences that prioritize internet-exposed systems; also added a short sentence introducing Iron Dillo’s GRIT model before the Monthly/Quarterly/Annual items.

### Testing
- Ran `python - <<'PY' ... HTMLParser().feed(...) ... PY` to validate the HTML parses correctly, and it completed successfully. 
- Ran `git diff --check` to detect whitespace and diff issues, which reported no problems. 
- Ran `git status --short` to confirm the working tree state after the edits, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6772d4fbbc8322a3284ace723d7c42)